### PR TITLE
Allow an existing tenant network to be used for seed host provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .terraform.lock.hcl
 *.tfstate*
 backend.tf
+venv

--- a/roles/infra/files/outputs.tf
+++ b/roles/infra/files/outputs.tf
@@ -20,7 +20,7 @@ output "cluster_nodes" {
           k3s_storage_device = openstack_compute_volume_attach_v2.capi_manager.device
           # Include the network id of the CAPI manager as a variable for provisioned hosts
           # This allows clusters to be placed onto the network by referencing this
-          capi_manager_network_id = openstack_networking_network_v2.capi_manager.id
+          capi_manager_network_id = data.openstack_networking_network_v2.capi_manager.id
           # Also include the keypair name for the same reason
           capi_manager_keypair = openstack_compute_keypair_v2.capi_manager_deploy.name
         }

--- a/roles/infra/files/resources.tf
+++ b/roles/infra/files/resources.tf
@@ -75,7 +75,7 @@ resource "openstack_compute_instance_v2" "capi_manager" {
   key_pair  = openstack_compute_keypair_v2.capi_manager_deploy.name
 
   network {
-    port = data.openstack_networking_port_v2.capi_manager.id
+    port = openstack_networking_port_v2.capi_manager.id
   }
 }
 

--- a/roles/infra/files/resources.tf
+++ b/roles/infra/files/resources.tf
@@ -28,6 +28,10 @@ resource "openstack_networking_network_v2" "capi_manager" {
   admin_state_up = "true"
 }
 
+data "openstack_networking_network_v2" "capi_manager" {
+  name       = openstack_networking_network_v2.capi_manager.name
+}
+
 resource "openstack_networking_subnet_v2" "capi_manager" {
   name       = var.cluster_name
   network_id = openstack_networking_network_v2.capi_manager.id
@@ -71,7 +75,7 @@ resource "openstack_compute_instance_v2" "capi_manager" {
   key_pair  = openstack_compute_keypair_v2.capi_manager_deploy.name
 
   network {
-    port = openstack_networking_port_v2.capi_manager.id
+    port = data.openstack_networking_port_v2.capi_manager.id
   }
 }
 

--- a/roles/infra/files/resources_existing_network.tf
+++ b/roles/infra/files/resources_existing_network.tf
@@ -1,0 +1,43 @@
+#####
+##### Terraform resources for provisioning a CAPI manager
+##### with an existing tenant network
+#####
+
+data "openstack_networking_network_v2" "capi_manager" {
+  name       = var.existing_network_name
+}
+
+resource "openstack_compute_keypair_v2" "capi_manager_deploy" {
+  name       = "capi-manager-deploy"
+}
+
+resource "openstack_compute_instance_v2" "capi_manager" {
+  name      = var.cluster_name
+  image_id  = var.image_id
+  flavor_id = var.flavor_id
+  key_pair  = openstack_compute_keypair_v2.capi_manager_deploy.name
+
+  network {
+    port = data.openstack_networking_port_v2.capi_manager.id
+  }
+}
+
+resource "openstack_blockstorage_volume_v3" "capi_manager_data" {
+  name = "${var.cluster_name}-data"
+  size = var.data_volume_size
+}
+
+resource "openstack_compute_volume_attach_v2" "capi_manager" {
+  instance_id = openstack_compute_instance_v2.capi_manager.id
+  volume_id   = openstack_blockstorage_volume_v3.capi_manager_data.id
+}
+
+resource "openstack_networking_floatingip_v2" "capi_manager_fip" {
+  pool = var.floatingip_pool
+}
+
+resource "openstack_compute_floatingip_associate_v2" "capi_manager" {
+  floating_ip = openstack_networking_floatingip_v2.capi_manager_fip.address
+  instance_id = openstack_compute_instance_v2.capi_manager.id
+}
+

--- a/roles/infra/files/resources_existing_network.tf
+++ b/roles/infra/files/resources_existing_network.tf
@@ -18,7 +18,7 @@ resource "openstack_compute_instance_v2" "capi_manager" {
   key_pair  = openstack_compute_keypair_v2.capi_manager_deploy.name
 
   network {
-    port = data.openstack_networking_port_v2.capi_manager.id
+    uuid = data.openstack_networking_network_v2.capi_manager.id
   }
 }
 

--- a/roles/infra/files/variables.tf
+++ b/roles/infra/files/variables.tf
@@ -6,11 +6,19 @@ variable "cluster_name" {
 variable "external_network_id" {
   type        = string
   description = "The ID of the external network to use"
+  default     = "false"
 }
 
 variable "network_cidr" {
   type        = string
   description = "The CIDR of the network"
+  default     = "false"
+}
+
+variable "existing_network_name" {
+  type        = string
+  description = "The name of an existing tenant network to use"
+  default     = "false"
 }
 
 variable "image_id" {

--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- name: Run prechecks
+  include_tasks: prechecks.yml
 
 - name: Make Terraform project directory
   file:
@@ -26,7 +28,8 @@
     terraform_project_path: "{{ inventory_dir }}/.terraform"
     terraform_variables:
       cluster_name: "{{ capi_manager_name }}"
-      network_cidr: "{{ capi_manager_network_cidr }}"
+      existing_network_name: "{{ capi_manager_existing_network_name | default(omit) }}"
+      network_cidr: "{{ capi_manager_network_cidr | default(omit) }}"
       image_id: "{{ capi_manager_image_id }}"
       flavor_id: "{{ capi_manager_flavor_id }}"
       external_network_id: "{{ capi_manager_external_network_id }}"

--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -14,8 +14,12 @@
   loop:
     - outputs.tf
     - providers.tf
-    - resources.tf
     - variables.tf
+
+- name: Copy Terraform files into project directory
+  copy:
+    src: "{% if capi_manager_existing_network_name is defined %}resources_existing_network.tf{% else %}resources.tf{% endif %}"
+    dest: "{{ inventory_dir }}/.terraform/resources.tf"
 
 - name: Provision infrastructure
   import_role:

--- a/roles/infra/tasks/prechecks.yml
+++ b/roles/infra/tasks/prechecks.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Test for incompatible configuration (capi_manager_existing_network_name NOR capi_manager_network_cidr)
+  fail:
+    msg: > 
+      Neither capi_manager_existing_network_name or capi_manager_network_cidr
+      are set. To use an exising network set capi_manager_existing_network_name
+      or set capi_manager_network_cidr to provision a new network.
+      with the specified CIDR.
+  when: capi_manager_existing_network_name is not defined and capi_manager_network_cidr is not defined
+
+- name: Test for incompatible configuration (capi_manager_existing_network_name AND capi_manager_network_cidr)
+  fail:
+    msg: >
+      Both capi_manager_existing_network_name and capi_manager_network_cidr
+      are set. To use an exising network set capi_manager_existing_network_name 
+      or set capi_manager_network_cidr to provision a new network.
+      with the specified CIDR.
+  when: capi_manager_existing_network_name is defined and capi_manager_network_cidr is defined


### PR DESCRIPTION
This makes `capi_manager_network_cidr` optional, and adds a new optional variable `capi_manager_existing_network_name`.

Using one or the other will dictate whether new network resources are provisioned with Terraform, or existing resources are rolled into the tfstate.