### PR TITLE
Add role to convert cloud images with qemu-img

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -6,6 +6,7 @@
 # Provision the node using Terraform
 - hosts: terraform_provision
   roles:
+    - stackhpc.azimuth_ops.image
     - stackhpc.azimuth_ops.infra
   vars:
     infra_ansible_groups: [k3s, azimuth_deploy]

--- a/roles/image/defaults/main.yml
+++ b/roles/image/defaults/main.yml
@@ -1,0 +1,1 @@
+image_format_conversion_dir: "/tmp"

--- a/roles/image/tasks/convert_image_format.yml
+++ b/roles/image/tasks/convert_image_format.yml
@@ -1,0 +1,51 @@
+---
+
+- name: Create temporary image download directory
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: image-download
+  register: download_tmpdir
+
+- name: Download image
+  ansible.builtin.get_url:
+    url: "{{ image.value.source_url }}"
+    dest: "{{ download_tmpdir.path }}"
+  register: image_download
+
+- name: Create temporary image conversion output directory
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: qemu-img-convert
+  register: convert_tmpdir
+
+- name: Convert image
+  ansible.builtin.command:
+    cmd: >
+      qemu-img convert -O {{ image.value.disk_format }}
+        {{ image_download.dest }}
+        {{ (convert_tmpdir.path, image.value.name) | path_join }}.{{ image.value.disk_format }}
+  
+- name: Get path of converted image file
+  ansible.builtin.find:
+    paths: "{{ convert_tmpdir.path }}"
+    use_regex: false
+    patterns: "{{ image.value.name }}.{{ image.value.disk_format }}"
+  register: converted_image
+    
+- name: Add the converted image path to infra_community_images
+  ansible.builtin.set_fact:
+    infra_community_images:
+      "{{ infra_community_images |
+        combine(
+          { 
+            image.key : { 
+              'local_file_path' : converted_image.files[0].path
+              } 
+            }, recursive=True
+          ) 
+        }}"
+
+- name: Clean up downloaded image
+  ansible.builtin.file:
+    path: "{{ image_download.dest }}"
+    state: absent

--- a/roles/image/tasks/convert_image_format.yml
+++ b/roles/image/tasks/convert_image_format.yml
@@ -3,6 +3,7 @@
 - name: Create temporary image download directory
   ansible.builtin.tempfile:
     state: directory
+    path: "{{ image_format_conversion_dir }}"
     suffix: image-download
   register: download_tmpdir
 

--- a/roles/image/tasks/main.yml
+++ b/roles/image/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Check image variables
+  ansible.builtin.fail:
+    msg: "Set either source_url OR local_file_path on image: {{ image.key }}"
+  loop: "{{ infra_community_images | dict2items }}"
+  loop_control:
+    label: "{{ image.key }}"
+    loop_var: image
+  when: >-
+    ( image.value.source_url is defined and image.value.local_file_path is defined ) or
+    ( image.value.source_url is not defined and image.value.local_file_path is not defined )
+
+- name: Install qemu-img
+  ansible.builtin.package:
+    name: qemu-img
+    state: present
+  become: true
+
+- name: Stage and convert cloud images
+  ansible.builtin.include_tasks: convert_image_format.yml
+  loop: "{{ infra_community_images | dict2items }}"
+  loop_control:
+    label: "{{ image.key }}"
+    loop_var: image
+  when: 
+    - image.value.source_url is defined 
+    - image.value.local_file_path is not defined

--- a/roles/infra/templates/resources.tf.j2
+++ b/roles/infra/templates/resources.tf.j2
@@ -1,9 +1,9 @@
 {% for image_id, image in infra_community_images.items() %}
 resource "openstack_images_image_v2" "{{ image_id }}" {
   name             = "{{ image.name }}"
-{% if image.local_file_path %}
+
   local_file_path = "{{ image.local_file_path }}"
-{% endif %}
+
   container_format = "{{ image.container_format }}"
   disk_format      = "{{ image.disk_format }}"
 

--- a/roles/infra/templates/resources.tf.j2
+++ b/roles/infra/templates/resources.tf.j2
@@ -17,9 +17,9 @@ resource "openstack_images_image_v2" "{{ image_id }}" {
   tags = ["azimuth_web_console_supported"]
 {% endif %}
 
-{% if image.properties %}
+{% if image.properties is defined %}
   properties = {
-{% for property_key, property_value in image.properties %}
+{% for property_key, property_value in image.properties.items() %}
     {{ property_key }} = "{{ property_value }}"
 {% endfor %} 
   }

--- a/roles/infra/templates/resources.tf.j2
+++ b/roles/infra/templates/resources.tf.j2
@@ -1,8 +1,8 @@
 {% for image_id, image in infra_community_images.items() %}
 resource "openstack_images_image_v2" "{{ image_id }}" {
   name             = "{{ image.name }}"
-{% if image.source_url %}
-  image_source_url = "{{ image.source_url }}"
+{% if image.local_file_path %}
+  local_file_path = "{{ image.local_file_path }}"
 {% endif %}
   container_format = "{{ image.container_format }}"
   disk_format      = "{{ image.disk_format }}"
@@ -15,6 +15,14 @@ resource "openstack_images_image_v2" "{{ image_id }}" {
 
 {% if "web_console_supported" in image and image.web_console_supported %}
   tags = ["azimuth_web_console_supported"]
+{% endif %}
+
+{% if image.properties %}
+  properties = {
+{% for property_key, property_value in image.properties %}
+    {{ property_key }} = "{{ property_value }}"
+{% endfor %} 
+  }
 {% endif %}
 }
 


### PR DESCRIPTION
Images are downloaded from `source_url` and converted to `disk_format` with `qemu-img convert`. Users may specify `local_file_path` if they are providing images from the local filesystem - these are assumed to be in the correct format.

Also adds the ability to set `properties` on each image using the `properties` dict in `infra_community_images`. 