### PR TITLE
Add azimuth_caas_awx_projects var

### DIFF
--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -267,6 +267,8 @@ azimuth_caas_stackhpc_slurm_appliance_project:
 # By default, the StackHPC Slurm appliance is included
 azimuth_caas_awx_default_projects:
   - "{{ azimuth_caas_stackhpc_slurm_appliance_project }}"
+
+azimuth_caas_awx_projects: []
 # - # The name of the project
 #   name: My Site Appliances
 #   # The git URL of the project
@@ -373,7 +375,10 @@ azimuth_release_defaults:
           "adminUsername": azimuth_caas_awx_admin_username,
           "adminPasswordSecretName": azimuth_caas_awx_admin_password_secret_name,
           "executionEnvironment": azimuth_caas_awx_ee,
-          "defaultProjects": azimuth_caas_awx_default_projects,
+          "defaultProjects": ( 
+          azimuth_caas_awx_default_projects + 
+          azimuth_caas_awx_projects 
+          ),
         },
         "terraformBackend": {
           "enabled": azimuth_caas_terraform_enabled,

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -268,7 +268,7 @@ azimuth_caas_stackhpc_slurm_appliance_project:
 azimuth_caas_awx_default_projects:
   - "{{ azimuth_caas_stackhpc_slurm_appliance_project }}"
 
-azimuth_caas_awx_projects: []
+azimuth_caas_awx_extra_projects: []
 # - # The name of the project
 #   name: My Site Appliances
 #   # The git URL of the project
@@ -298,6 +298,8 @@ azimuth_caas_awx_projects: []
 #     image: registry.example.com/org/image:tag
 #     # Whether to re-pull the image each time it is required (defaults to false if not given)
 #     alwaysPull: true
+
+azimuth_caas_awx_projects: "{{ azimuth_caas_awx_default_projects + azimuth_caas_awx_extra_projects }}"
 
 # Theme settings
 #   Custom bootstrap CSS URL
@@ -375,10 +377,7 @@ azimuth_release_defaults:
           "adminUsername": azimuth_caas_awx_admin_username,
           "adminPasswordSecretName": azimuth_caas_awx_admin_password_secret_name,
           "executionEnvironment": azimuth_caas_awx_ee,
-          "defaultProjects": ( 
-          azimuth_caas_awx_default_projects + 
-          azimuth_caas_awx_projects 
-          ),
+          "defaultProjects": azimuth_caas_awx_projects,
         },
         "terraformBackend": {
           "enabled": azimuth_caas_terraform_enabled,


### PR DESCRIPTION
Allow a list of CaaS projects to be provided in `azimuth_caas_awx_projects`, which is added to `azimuth_caas_awx_default_projects` to create the full list of CaaS AWX projects.