### PR TITLE
Feat/set image properties

### DIFF
--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -267,6 +267,8 @@ azimuth_caas_stackhpc_slurm_appliance_project:
 # By default, the StackHPC Slurm appliance is included
 azimuth_caas_awx_default_projects:
   - "{{ azimuth_caas_stackhpc_slurm_appliance_project }}"
+
+azimuth_caas_awx_projects: []
 # - # The name of the project
 #   name: My Site Appliances
 #   # The git URL of the project
@@ -373,7 +375,10 @@ azimuth_release_defaults:
           "adminUsername": azimuth_caas_awx_admin_username,
           "adminPasswordSecretName": azimuth_caas_awx_admin_password_secret_name,
           "executionEnvironment": azimuth_caas_awx_ee,
-          "defaultProjects": azimuth_caas_awx_default_projects,
+          "defaultProjects": ( 
+          azimuth_caas_awx_default_projects + 
+          azimuth_caas_awx_projects 
+          ),
         },
         "terraformBackend": {
           "enabled": azimuth_caas_terraform_enabled,

--- a/roles/infra/templates/resources.tf.j2
+++ b/roles/infra/templates/resources.tf.j2
@@ -17,6 +17,16 @@ resource "openstack_images_image_v2" "{{ image_id }}" {
   tags = ["azimuth_web_console_supported"]
 {% endif %}
 
+{% if "properties" in image %}
+  properties = {{ image.properties | to_nice_json() }}
+{% endif %}
+
+{% if "verify_checksum" in image and not image.verify_checksum %}
+  verify_checksum = "false"
+{% elif "verfy_checksum" in image and image.verify_checksum %}
+  verify_checksum = "true"
+{% endif %}
+
   lifecycle {
     ignore_changes = [
       image_source_url,


### PR DESCRIPTION
Expose Terraform `openstack_images_image_v2.properties` and `openstack_images_image_v2.verify_checksum`. Allows the setting of image properties like those described in https://docs.ceph.com/en/latest/rbd/rbd-openstack/#image-properties.

Images uploaded to VMWare clouds must have `verify_checksum` turned off.