### PR TITLE
Set image properties and verify_checksum

### DIFF
--- a/roles/infra/templates/resources.tf.j2
+++ b/roles/infra/templates/resources.tf.j2
@@ -17,6 +17,16 @@ resource "openstack_images_image_v2" "{{ image_id }}" {
   tags = ["azimuth_web_console_supported"]
 {% endif %}
 
+{% if "properties" in image %}
+  properties = {{ image.properties | to_nice_json() }} 
+{% endif %}
+
+{% if "verify_checksum" in image and not image.verify_checksum %}
+  verify_checksum = "false"
+{% elif "verfy_checksum" in image and image.verify_checksum %}
+  verify_checksum = "true"
+{% endif %}
+
   lifecycle {
     ignore_changes = [
       image_source_url,


### PR DESCRIPTION
Expose Terraform openstack_images_image_v2.properties and openstack_images_image_v2.verify_checksum. Allows the setting of image properties like those described in https://docs.ceph.com/en/latest/rbd/rbd-openstack/#image-properties.

Images uploaded to VMWare clouds must have verify_checksum turned off.

Fixes https://github.com/stackhpc/ansible-collection-azimuth-ops/issues/7