### PR TITLE
Include the ingress_nginx role in the deploy playbook

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -17,6 +17,8 @@
       when: azimuth_clusters_enabled
     - role: stackhpc.azimuth_ops.consul
       when: azimuth_apps_enabled or azimuth_clusters_enabled
+    - role: stackhpc.azimuth_ops.ingress_nginx
+      when: azimuth_apps_enabled
     - role: stackhpc.azimuth_ops.zenith
       when: azimuth_apps_enabled
     - role: stackhpc.azimuth_ops.azimuth_capi_operator


### PR DESCRIPTION
Since Zenith's sync containers expect the NGINX Ingress Controller to be
available, add the role creating it to the deploy playbook.