### PR TITLE
cope with multiple pre-existing images of the same name

### DIFF
--- a/roles/community_images/tasks/upload_image.yml
+++ b/roles/community_images/tasks/upload_image.yml
@@ -25,18 +25,26 @@
 # openstack.cloud.image_info does not respect clouds.yaml in the current working directory
 # So use the OpenStack CLI directly instead
 - name: "Check if image exists - {{ community_images_image_spec.name }}"
-  command: "openstack image show -f json {{ community_images_image_spec.name }}"
+  command: "openstack image list -f json --name {{ community_images_image_spec.name }}"
   changed_when: false
   failed_when: >-
-    community_images_image_info.rc != 0 and
-    "no image found" not in community_images_image_info.stderr.lower()
+    community_images_all.rc != 0 and
+    "no image found" not in community_images_all.stderr.lower()
+  register: community_images_all
+
+- name: "Get facts from pre-existing image - {{ community_images_image_spec.name }}"
+  command: "openstack image show -f json {{ community_images_all.stdout | from_json | json_query('[0].ID') }}"
+  changed_when: false
   register: community_images_image_info
+  when: community_images_all.rc == 0
 
 - name: "Set facts from pre-existing image - {{ community_images_image_spec.name }}"
   set_fact:
     community_images_image_id: "{{ community_images_image_info.stdout | from_json | json_query('id') }}"
     community_images_image_current_visibility: "{{ community_images_image_info.stdout | from_json | json_query('visibility') }}"
-  when: community_images_image_info.rc == 0
+  when:
+    - community_images_all.rc == 0
+    - community_images_image_info.rc == 0
 
 - block:
     - name: "Set image facts - {{ community_images_image_spec.name }}"
@@ -119,7 +127,7 @@
       set_fact:
         community_images_image_id: "{{ community_images_create_image_cmd.stdout | from_json | json_query('id') }}"
         community_images_image_current_visibility: "{{ community_images_create_image_cmd.stdout | from_json | json_query('visibility') }}"
-  when: community_images_image_info.rc != 0
+  when: community_images_all.rc != 0
 
 - name: "Set image visibility fact - {{ community_images_image_spec.name }}"
   set_fact:


### PR DESCRIPTION
If multiple images exist for `community_images_image_spec.name`, just use the first one.