### PR TITLE
Use updated CaaS slurm appliance

### DIFF
--- a/roles/awx/defaults/main.yml
+++ b/roles/awx/defaults/main.yml
@@ -94,7 +94,7 @@ awx_ee_resource_requirements:
     memory: 1Gi
 
 # The image to use as the control plane ee image
-awx_control_plane_ee_image: "quay.io/ansible/awx-ee@sha256:1b9564e397a5059b53d304a697fcc48250fb805caf828a8006ef799d69a8dd21"
+awx_control_plane_ee_image: "quay.io/ansible/awx-ee:latest"
 
 # The spec for the AWX instance
 awx_spec_defaults: >-

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -327,7 +327,7 @@ azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
 azimuth_caas_stackhpc_slurm_appliance_playbooks: [slurm-infra.yml]
 # The ID of the image to use with the StackHPC Slurm appliance
 # Support the old name for backwards compatibility
-# By default, use the Rocky 8 image from community images if available
+# By default, use the openhpc image from community images if available
 azimuth_caas_stackhpc_slurm_appliance_image: >-
   {{-
     azimuth_caas_stackhpc_slurm_appliance_rocky8_image
@@ -337,7 +337,7 @@ azimuth_caas_stackhpc_slurm_appliance_image: >-
         community_images_image_ids.openhpc_220830_2042
         if (
           community_images_image_ids is defined and
-          'rocky_8_20220702' in community_images_image_ids
+          'openhpc_220830_2042' in community_images_image_ids
         )
         else undef(hint = 'azimuth_caas_stackhpc_slurm_appliance_image is required')
       )

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -326,7 +326,7 @@ azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
 # The playbooks to use for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_playbooks: [slurm-infra.yml]
 # Always update the cloned StackHPC Slurm appliance repo - useful for development on a branch
-azimuth_caas_stackhpc_slurm_appliance_alwaysUpdate: false
+azimuth_caas_stackhpc_slurm_appliance_always_update: false
 # The ID of the image to use with the StackHPC Slurm appliance
 # Support the old name for backwards compatibility
 # By default, use the openhpc image from community images if available
@@ -382,7 +382,7 @@ azimuth_caas_stackhpc_slurm_appliance_project:
   metadataRoot: "{{ azimuth_caas_stackhpc_slurm_appliance_metadata_root }}"
   playbooks: "{{ azimuth_caas_stackhpc_slurm_appliance_playbooks }}"
   extraVars: "{{ azimuth_caas_stackhpc_slurm_appliance_extra_vars }}"
-  alwaysUpdate: "{{ azimuth_caas_stackhpc_slurm_appliance_alwaysUpdate }}"
+  alwaysUpdate: "{{ azimuth_caas_stackhpc_slurm_appliance_always_update }}"
 
 # Indicates if the StackHPC workstation should be enabled
 azimuth_caas_stackhpc_workstation_enabled: "{{ azimuth_clusters_enabled }}"

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -319,7 +319,7 @@ azimuth_caas_stackhpc_slurm_appliance_name: StackHPC Slurm Appliance
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/caas-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: a34d00a4de7abe8fa6ca5337096be0e56aee24ef
+azimuth_caas_stackhpc_slurm_appliance_git_version: f60aabd68e45e7d1f9d3265e8ec6f47d060be1c0
 # The metadata root for the StackHPC Slurm appliance project
 azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/ui-meta
@@ -367,8 +367,6 @@ azimuth_caas_stackhpc_slurm_appliance_extra_vars_defaults:
   cluster_image: "{{ azimuth_caas_stackhpc_slurm_appliance_image }}"
   login_flavor_name: "{{ azimuth_caas_stackhpc_slurm_appliance_login_flavor_name }}"
   control_flavor_name: "{{ azimuth_caas_stackhpc_slurm_appliance_control_flavor_name }}"
-  # Cluster state-volume size in GB
-  cluster_state_volume_size: "{{ azimuth_caas_stackhpc_slurm_appliance_state_volume_size | default('40') }}"
 
 # extra_vars overrides for templates in the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_extra_vars_overrides: {}

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -319,7 +319,7 @@ azimuth_caas_stackhpc_slurm_appliance_name: StackHPC Slurm Appliance
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/caas-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: f60aabd68e45e7d1f9d3265e8ec6f47d060be1c0
+azimuth_caas_stackhpc_slurm_appliance_git_version: 2b719b24247f4a59b39c48944b6c3abb12ef6fbd
 # The metadata root for the StackHPC Slurm appliance project
 azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/ui-meta

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -319,7 +319,7 @@ azimuth_caas_stackhpc_slurm_appliance_name: StackHPC Slurm Appliance
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/caas-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: 19a7032b69073de91d747f99fe22259152d616f0
+azimuth_caas_stackhpc_slurm_appliance_git_version: e5d51a314b05c01fc844565e7a101d8edbf6e73a
 # The metadata root for the StackHPC Slurm appliance project
 azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/ui-meta

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -325,6 +325,8 @@ azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/ui-meta
 # The playbooks to use for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_playbooks: [slurm-infra.yml]
+# Always update the cloned StackHPC Slurm appliance repo - useful for development on a branch
+azimuth_caas_stackhpc_slurm_appliance_alwaysUpdate: false
 # The ID of the image to use with the StackHPC Slurm appliance
 # Support the old name for backwards compatibility
 # By default, use the openhpc image from community images if available
@@ -373,6 +375,7 @@ azimuth_caas_stackhpc_slurm_appliance_project:
   metadataRoot: "{{ azimuth_caas_stackhpc_slurm_appliance_metadata_root }}"
   playbooks: "{{ azimuth_caas_stackhpc_slurm_appliance_playbooks }}"
   extraVars: "{{ azimuth_caas_stackhpc_slurm_appliance_extra_vars }}"
+  alwaysUpdate: "{{ azimuth_caas_stackhpc_slurm_appliance_alwaysUpdate }}"
 
 # Indicates if the StackHPC workstation should be enabled
 azimuth_caas_stackhpc_workstation_enabled: "{{ azimuth_clusters_enabled }}"

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -319,7 +319,7 @@ azimuth_caas_stackhpc_slurm_appliance_name: StackHPC Slurm Appliance
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/caas-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: 3b115f03a673f876675813099531e75a4d9a13a7
+azimuth_caas_stackhpc_slurm_appliance_git_version: update/2022-9-29
 # The metadata root for the StackHPC Slurm appliance project
 azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/ui-meta
@@ -373,6 +373,7 @@ azimuth_caas_stackhpc_slurm_appliance_project:
   metadataRoot: "{{ azimuth_caas_stackhpc_slurm_appliance_metadata_root }}"
   playbooks: "{{ azimuth_caas_stackhpc_slurm_appliance_playbooks }}"
   extraVars: "{{ azimuth_caas_stackhpc_slurm_appliance_extra_vars }}"
+  alwaysUpdate: true
 
 # Indicates if the StackHPC workstation should be enabled
 azimuth_caas_stackhpc_workstation_enabled: "{{ azimuth_clusters_enabled }}"

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -362,17 +362,17 @@ azimuth_caas_stackhpc_slurm_appliance_control_flavor_name: >-
     else None
   }}
 
-# The base extra vars for templates in the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_extra_vars_base:
+# The default extra vars for templates in the StackHPC Slurm appliance
+azimuth_caas_stackhpc_slurm_appliance_extra_vars_defaults:
   cluster_image: "{{ azimuth_caas_stackhpc_slurm_appliance_image }}"
   login_flavor_name: "{{ azimuth_caas_stackhpc_slurm_appliance_login_flavor_name }}"
   control_flavor_name: "{{ azimuth_caas_stackhpc_slurm_appliance_control_flavor_name }}"
 
-# Additional extra vars for templates in the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_extra_vars_extra: {}
+# extra_vars overrides for templates in the StackHPC Slurm appliance
+azimuth_caas_stackhpc_slurm_appliance_extra_vars_overrides: {}
 
 azimuth_caas_stackhpc_slurm_appliance_extra_vars:
-  __ALL__: "{{ azimuth_caas_stackhpc_slurm_appliance_extra_vars_base | combine(azimuth_caas_stackhpc_slurm_appliance_extra_vars_extra) }}"
+  __ALL__: "{{ azimuth_caas_stackhpc_slurm_appliance_extra_vars_defaults | combine(azimuth_caas_stackhpc_slurm_appliance_extra_vars_overrides) }}"
 
 # The project definition for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_project:
@@ -421,15 +421,15 @@ azimuth_caas_stackhpc_workstation_image: >-
     else None
   }}
 
-# The base extra vars for templates in the StackHPC workstation
-azimuth_caas_stackhpc_workstation_extra_vars_base:
+# The default extra vars for templates in the StackHPC workstation
+azimuth_caas_stackhpc_workstation_extra_vars_defaults:
     cluster_image: "{{ azimuth_caas_stackhpc_workstation_image }}"
 
-# Additional extra vars for templates in the StackHPC workstation
-azimuth_caas_stackhpc_workstation_extra_vars_extra: {}
+# extra_vars overrides for templates in the StackHPC workstation
+azimuth_caas_stackhpc_workstation_extra_vars_overrides: {}
 
 azimuth_caas_stackhpc_workstation_extra_vars:
-  __ALL__: "{{ azimuth_caas_stackhpc_workstation_extra_vars_base | combine(azimuth_caas_stackhpc_workstation_extra_vars_extra) }}"
+  __ALL__: "{{ azimuth_caas_stackhpc_workstation_extra_vars_defaults | combine(azimuth_caas_stackhpc_workstation_extra_vars_overrides) }}"
 
 # The project definition for the StackHPC workstation
 azimuth_caas_stackhpc_workstation_project:
@@ -469,15 +469,15 @@ azimuth_caas_stackhpc_repo2docker_image: >-
     else None
   }}
 
-# The base extra vars for templates in the StackHPC repo2docker appliance
-azimuth_caas_stackhpc_repo2docker_extra_vars_base:
+# The default extra vars for templates in the StackHPC repo2docker appliance
+azimuth_caas_stackhpc_repo2docker_extra_vars_defaults:
   cluster_image: "{{ azimuth_caas_stackhpc_repo2docker_image }}"
 
-# Additional extra vars for templates in the StackHPC repo2docker appliance
-azimuth_caas_stackhpc_repo2docker_extra_vars_extra: {}
+# extra_vars overrides for templates in the StackHPC repo2docker appliance
+azimuth_caas_stackhpc_repo2docker_extra_vars_overrides: {}
 
 azimuth_caas_stackhpc_repo2docker_extra_vars:
-  __ALL__: "{{ azimuth_caas_stackhpc_repo2docker_extra_vars_base | combine(azimuth_caas_stackhpc_repo2docker_extra_vars_extra) }}"
+  __ALL__: "{{ azimuth_caas_stackhpc_repo2docker_extra_vars_defaults | combine(azimuth_caas_stackhpc_repo2docker_extra_vars_overrides) }}"
 
 # The project definition for the StackHPC repo2docker appliance
 azimuth_caas_stackhpc_repo2docker_project:

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -319,7 +319,7 @@ azimuth_caas_stackhpc_slurm_appliance_name: StackHPC Slurm Appliance
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/caas-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: ef72178edbfdc7cccb943057604f8422595a7ebc
+azimuth_caas_stackhpc_slurm_appliance_git_version: a34d00a4de7abe8fa6ca5337096be0e56aee24ef
 # The metadata root for the StackHPC Slurm appliance project
 azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/ui-meta

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -319,7 +319,7 @@ azimuth_caas_stackhpc_slurm_appliance_name: StackHPC Slurm Appliance
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/caas-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: update/2022-9-29
+azimuth_caas_stackhpc_slurm_appliance_git_version: 19a7032b69073de91d747f99fe22259152d616f0
 # The metadata root for the StackHPC Slurm appliance project
 azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/ui-meta
@@ -361,12 +361,19 @@ azimuth_caas_stackhpc_slurm_appliance_control_flavor_name: >-
     if azimuth_caas_stackhpc_slurm_appliance_enabled
     else None
   }}
-# The extra vars for templates in the StackHPC Slurm appliance
+
+# The base extra vars for templates in the StackHPC Slurm appliance
+azimuth_caas_stackhpc_slurm_appliance_extra_vars_base:
+  cluster_image: "{{ azimuth_caas_stackhpc_slurm_appliance_image }}"
+  login_flavor_name: "{{ azimuth_caas_stackhpc_slurm_appliance_login_flavor_name }}"
+  control_flavor_name: "{{ azimuth_caas_stackhpc_slurm_appliance_control_flavor_name }}"
+
+# Additional extra vars for templates in the StackHPC Slurm appliance
+azimuth_caas_stackhpc_slurm_appliance_extra_vars_extra: {}
+
 azimuth_caas_stackhpc_slurm_appliance_extra_vars:
-  __ALL__:
-    cluster_image: "{{ azimuth_caas_stackhpc_slurm_appliance_image }}"
-    login_flavor_name: "{{ azimuth_caas_stackhpc_slurm_appliance_login_flavor_name }}"
-    control_flavor_name: "{{ azimuth_caas_stackhpc_slurm_appliance_control_flavor_name }}"
+  __ALL__: "{{ azimuth_caas_stackhpc_slurm_appliance_extra_vars_base | combine(azimuth_caas_stackhpc_slurm_appliance_extra_vars_extra) }}"
+
 # The project definition for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_project:
   name: "{{ azimuth_caas_stackhpc_slurm_appliance_name }}"
@@ -413,10 +420,17 @@ azimuth_caas_stackhpc_workstation_image: >-
     if azimuth_caas_stackhpc_workstation_enabled
     else None
   }}
-# The extra vars for templates in the StackHPC workstation
-azimuth_caas_stackhpc_workstation_extra_vars:
-  __ALL__:
+
+# The base extra vars for templates in the StackHPC workstation
+azimuth_caas_stackhpc_workstation_extra_vars_base:
     cluster_image: "{{ azimuth_caas_stackhpc_workstation_image }}"
+
+# Additional extra vars for templates in the StackHPC workstation
+azimuth_caas_stackhpc_workstation_extra_vars_extra: {}
+
+azimuth_caas_stackhpc_workstation_extra_vars:
+  __ALL__: "{{ azimuth_caas_stackhpc_workstation_extra_vars_base | combine(azimuth_caas_stackhpc_workstation_extra_vars_extra) }}"
+
 # The project definition for the StackHPC workstation
 azimuth_caas_stackhpc_workstation_project:
   name: "{{ azimuth_caas_stackhpc_workstation_name }}"
@@ -454,10 +468,17 @@ azimuth_caas_stackhpc_repo2docker_image: >-
     if azimuth_caas_stackhpc_repo2docker_enabled
     else None
   }}
-# The extra vars for templates in the StackHPC repo2docker appliance
+
+# The base extra vars for templates in the StackHPC repo2docker appliance
+azimuth_caas_stackhpc_repo2docker_extra_vars_base:
+  cluster_image: "{{ azimuth_caas_stackhpc_repo2docker_image }}"
+
+# Additional extra vars for templates in the StackHPC repo2docker appliance
+azimuth_caas_stackhpc_repo2docker_extra_vars_extra: {}
+
 azimuth_caas_stackhpc_repo2docker_extra_vars:
-  __ALL__:
-    cluster_image: "{{ azimuth_caas_stackhpc_repo2docker_image }}"
+  __ALL__: "{{ azimuth_caas_stackhpc_repo2docker_extra_vars_base | combine(azimuth_caas_stackhpc_repo2docker_extra_vars_extra) }}"
+
 # The project definition for the StackHPC repo2docker appliance
 azimuth_caas_stackhpc_repo2docker_project:
   name: "{{ azimuth_caas_stackhpc_repo2docker_name }}"

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -319,7 +319,7 @@ azimuth_caas_stackhpc_slurm_appliance_name: StackHPC Slurm Appliance
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/caas-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: e5d51a314b05c01fc844565e7a101d8edbf6e73a
+azimuth_caas_stackhpc_slurm_appliance_git_version: ef72178edbfdc7cccb943057604f8422595a7ebc
 # The metadata root for the StackHPC Slurm appliance project
 azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/ui-meta
@@ -367,6 +367,8 @@ azimuth_caas_stackhpc_slurm_appliance_extra_vars_defaults:
   cluster_image: "{{ azimuth_caas_stackhpc_slurm_appliance_image }}"
   login_flavor_name: "{{ azimuth_caas_stackhpc_slurm_appliance_login_flavor_name }}"
   control_flavor_name: "{{ azimuth_caas_stackhpc_slurm_appliance_control_flavor_name }}"
+  # Cluster state-volume size in GB
+  cluster_state_volume_size: "{{ azimuth_caas_stackhpc_slurm_appliance_state_volume_size | default('40') }}"
 
 # extra_vars overrides for templates in the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_extra_vars_overrides: {}

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -373,7 +373,6 @@ azimuth_caas_stackhpc_slurm_appliance_project:
   metadataRoot: "{{ azimuth_caas_stackhpc_slurm_appliance_metadata_root }}"
   playbooks: "{{ azimuth_caas_stackhpc_slurm_appliance_playbooks }}"
   extraVars: "{{ azimuth_caas_stackhpc_slurm_appliance_extra_vars }}"
-  alwaysUpdate: true
 
 # Indicates if the StackHPC workstation should be enabled
 azimuth_caas_stackhpc_workstation_enabled: "{{ azimuth_clusters_enabled }}"

--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -334,7 +334,7 @@ azimuth_caas_stackhpc_slurm_appliance_image: >-
     if azimuth_caas_stackhpc_slurm_appliance_rocky8_image is defined
     else (
       (
-        community_images_image_ids.rocky_8_20220702
+        community_images_image_ids.openhpc_220830_2042
         if (
           community_images_image_ids is defined and
           'rocky_8_20220702' in community_images_image_ids

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -62,9 +62,9 @@ community_images_default:
     source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_f0dc9cb312144d0aa44037c9149d2513/azimuth-images-prerelease/ubuntu-focal-desktop-220810-0904.qcow2
     source_disk_format: qcow2
     container_format: bare
-  rocky_8_20220702:
-    name: rocky-8-20220702
-    source_url: http://download.rockylinux.org/pub/rocky/8.6/images/Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2
+  openhpc_220830_2042:
+    name: openhpc-220830-2042
+    source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images/openhpc-220830-2042.qcow2
     source_disk_format: qcow2
     container_format: bare
 


### PR DESCRIPTION
- Uses the updated slurm app provided by https://github.com/stackhpc/caas-slurm-appliance/pull/10/.
- Uses the "fat" prebuild images produced by https://github.com/stackhpc/slurm_image_builder/

