### PR TITLE
Change Slurm image to openhpc_221027_1557.qcow2.

### DIFF
--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -336,10 +336,10 @@ azimuth_caas_stackhpc_slurm_appliance_image: >-
     if azimuth_caas_stackhpc_slurm_appliance_rocky8_image is defined
     else (
       (
-        community_images_image_ids.openhpc_220830_2042
+        community_images_image_ids.openhpc_221027_1557
         if (
           community_images_image_ids is defined and
-          'openhpc_220830_2042' in community_images_image_ids
+          'openhpc_221027_1557' in community_images_image_ids
         )
         else undef(hint = 'azimuth_caas_stackhpc_slurm_appliance_image is required')
       )

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -62,9 +62,9 @@ community_images_default:
     source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_f0dc9cb312144d0aa44037c9149d2513/azimuth-images-prerelease/ubuntu-focal-desktop-221017-1036.qcow2
     source_disk_format: qcow2
     container_format: bare
-  openhpc_220830_2042:
-    name: openhpc-220830-2042
-    source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images/openhpc-220830-2042.qcow2
+  openhpc_221027_1557:
+    name: openhpc-221027-1557
+    source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images/openhpc-221027-1557.qcow2
     source_disk_format: qcow2
     container_format: bare
 


### PR DESCRIPTION
Removes rocky ssh keys baked in to previous image.