### PR TITLE
Bump caas to image-based patch version

### DIFF
--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -366,7 +366,7 @@ azimuth_caas_stackhpc_slurm_appliance_name: StackHPC Slurm Appliance
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/caas-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: 726ba77e7870b1586dc078d048c347499a32a710
+azimuth_caas_stackhpc_slurm_appliance_git_version: 776d5df40847f11d30de1564282cd48438f7891a
 # The metadata root for the StackHPC Slurm appliance project
 azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/ui-meta


### PR DESCRIPTION
Update CaaS version to use https://github.com/stackhpc/caas-slurm-appliance/pull/11