### PR TITLE
Bump slurm image to fix ohpc-base-compute and RL8.7

### DIFF
--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -67,9 +67,9 @@ community_images_default:
     source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_f0dc9cb312144d0aa44037c9149d2513/azimuth-images-prerelease/ubuntu-focal-desktop-221017-1036.qcow2
     source_disk_format: qcow2
     container_format: bare
-  openhpc_221118_1422:
-    name: openhpc-221118-1422
-    source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images/openhpc-221118-1422.qcow2
+  openhpc-230106-1107:
+    name: openhpc-230106-1107
+    source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images/openhpc-230106-1107.qcow2
     source_disk_format: qcow2
     container_format: bare
 


### PR DESCRIPTION
See https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.123