### PR TITLE
Bump caas-workstation version

### DIFF
--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -448,7 +448,7 @@ azimuth_caas_stackhpc_workstation_name: StackHPC Workstation
 # The git URL for the StackHPC workstation
 azimuth_caas_stackhpc_workstation_git_url: https://github.com/stackhpc/caas-workstation.git
 # The git version for the StackHPC workstation
-azimuth_caas_stackhpc_workstation_git_version: 0c5c215df45c4ecd9f5c682a8115f547f269ae7b
+azimuth_caas_stackhpc_workstation_git_version: 2be5021523fbd1652737fc61f82138a78d29df0b
 # The metadata root for the StackHPC workstation project
 azimuth_caas_stackhpc_workstation_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-workstation/{{ azimuth_caas_stackhpc_workstation_git_version }}/ui-meta


### PR DESCRIPTION
Adds a second workstation platform that allows users to choose the volume-type for their data volume.