### PR TITLE
Bump versions of workstation and slurm

### DIFF
--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -366,7 +366,7 @@ azimuth_caas_stackhpc_slurm_appliance_name: StackHPC Slurm Appliance
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/caas-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: 683f0170d4a2d579b07ec2c4a463e8319076c115
+azimuth_caas_stackhpc_slurm_appliance_git_version: 7af143e6ff746f4e81e2368784a1d85a72d99bd5
 # The metadata root for the StackHPC Slurm appliance project
 azimuth_caas_stackhpc_slurm_appliance_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/ui-meta
@@ -448,7 +448,7 @@ azimuth_caas_stackhpc_workstation_name: StackHPC Workstation
 # The git URL for the StackHPC workstation
 azimuth_caas_stackhpc_workstation_git_url: https://github.com/stackhpc/caas-workstation.git
 # The git version for the StackHPC workstation
-azimuth_caas_stackhpc_workstation_git_version: 0c5c215df45c4ecd9f5c682a8115f547f269ae7b
+azimuth_caas_stackhpc_workstation_git_version: 9756b5ada387ca2ca6b51d6ed9a2f7a411124e56
 # The metadata root for the StackHPC workstation project
 azimuth_caas_stackhpc_workstation_metadata_root: >-
   https://raw.githubusercontent.com/stackhpc/caas-workstation/{{ azimuth_caas_stackhpc_workstation_git_version }}/ui-meta


### PR DESCRIPTION
Workstation: https://github.com/stackhpc/caas-workstation/pull/7
Slurm: https://github.com/stackhpc/caas-slurm-appliance/pull/21