### PR TITLE
Bump slurm image for slurm app v1.126 to support containerised workloads

### DIFF
--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -383,10 +383,10 @@ azimuth_caas_stackhpc_slurm_appliance_image: >-
     if azimuth_caas_stackhpc_slurm_appliance_rocky8_image is defined
     else (
       (
-        community_images_image_ids.openhpc_230110_1629
+        community_images_image_ids.openhpc_230217_1440
         if (
           community_images_image_ids is defined and
-          'openhpc_230110_1629' in community_images_image_ids
+          'openhpc_230217_1440' in community_images_image_ids
         )
         else undef(hint = 'azimuth_caas_stackhpc_slurm_appliance_image is required')
       )

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -67,9 +67,9 @@ community_images_default:
     source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_f0dc9cb312144d0aa44037c9149d2513/azimuth-images-prerelease/ubuntu-focal-desktop-221017-1036.qcow2
     source_disk_format: qcow2
     container_format: bare
-  openhpc_230110_1629:
-    name: openhpc-230110-1629
-    source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images/openhpc-230110-1629.qcow2
+  openhpc_230217_1440:
+    name: openhpc-230217-1440
+    source_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images/openhpc-230217-1440.qcow2
     source_disk_format: qcow2
     container_format: bare
 


### PR DESCRIPTION
Update CaaS to https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.126