### PR TITLE
Bump Zenith chart version to 0.1.0-dev.0.main.219

### DIFF
--- a/roles/zenith/defaults/main.yml
+++ b/roles/zenith/defaults/main.yml
@@ -3,7 +3,7 @@
 # The chart to use
 zenith_chart_repo: https://stackhpc.github.io/zenith
 zenith_chart_name: zenith-server
-zenith_chart_version: 0.1.0-dev.0.main.216
+zenith_chart_version: 0.1.0-dev.0.main.219
 
 # Release information for the Zenith release
 # Use the same namespace as the Azimuth release by default


### PR DESCRIPTION
New Zenith version adds additional logging and simplifies the retry/reconciliation process during service sync.