### PR TITLE
Add support for using azimuth-images manifests

### DIFF
--- a/roles/azimuth_capi_operator/defaults/main.yml
+++ b/roles/azimuth_capi_operator/defaults/main.yml
@@ -379,85 +379,31 @@ azimuth_capi_operator_release_values: >-
 # All other templates will be marked as DEPRECATED
 # azimuth-ops currently never removes templates
 #####
-# By default use the community images
-azimuth_capi_operator_kube_1_23_16_image: >-
-  {{-
-    community_images_image_ids.kube_1_23_16
-    if (
-      community_images_image_ids is defined and
-      'kube_1_23_16' in community_images_image_ids
-    )
-    else undef(hint = 'azimuth_capi_operator_kube_1_23_16_image is required')
-  }}
-azimuth_capi_operator_kube_1_24_12_image: >-
-  {{-
-    community_images_image_ids.kube_1_24_12
-    if (
-      community_images_image_ids is defined and
-      'kube_1_24_12' in community_images_image_ids
-    )
-    else undef(hint = 'azimuth_capi_operator_kube_1_24_12_image is required')
-  }}
-azimuth_capi_operator_kube_1_25_8_image: >-
-  {{-
-    community_images_image_ids.kube_1_25_8
-    if (
-      community_images_image_ids is defined and
-      'kube_1_25_8' in community_images_image_ids
-    )
-    else undef(hint = 'azimuth_capi_operator_kube_1_25_8_image is required')
-  }}
-azimuth_capi_operator_kube_1_26_3_image: >-
-  {{-
-    community_images_image_ids.kube_1_26_3
-    if (
-      community_images_image_ids is defined and
-      'kube_1_26_3' in community_images_image_ids
-    )
-    else undef(hint = 'azimuth_capi_operator_kube_1_26_3_image is required')
-  }}
-# By default, make templates for the latest patch versions of the supported Kubernetes releases
-azimuth_capi_operator_cluster_templates_default:
-  kube-1-23-16:
-    label: v1.23.16
-    description: Kubernetes 1.23.16 with HA control plane.
-    values:
-      kubernetesVersion: 1.23.16
-      machineImageId: "{{ azimuth_capi_operator_kube_1_23_16_image }}"
-      clusterNetworking:
-        internalNetwork:
-          networkFilter:
-            tags: portal-internal
-  kube-1-24-12:
-    label: v1.24.12
-    description: Kubernetes 1.24.12 with HA control plane.
-    values:
-      kubernetesVersion: 1.24.12
-      machineImageId: "{{ azimuth_capi_operator_kube_1_24_12_image }}"
-      clusterNetworking:
-        internalNetwork:
-          networkFilter:
-            tags: portal-internal
-  kube-1-25-8:
-    label: v1.25.8
-    description: Kubernetes 1.25.8 with HA control plane.
-    values:
-      kubernetesVersion: 1.25.8
-      machineImageId: "{{ azimuth_capi_operator_kube_1_25_8_image }}"
-      clusterNetworking:
-        internalNetwork:
-          networkFilter:
-            tags: portal-internal
-  kube-1-26-3:
-    label: v1.26.3
-    description: Kubernetes 1.26.3 with HA control plane.
-    values:
-      kubernetesVersion: 1.26.3
-      machineImageId: "{{ azimuth_capi_operator_kube_1_26_3_image }}"
-      clusterNetworking:
-        internalNetwork:
-          networkFilter:
-            tags: portal-internal
+# By default, make a template for each Kubernetes release for which we have an image
+azimuth_capi_operator_cluster_templates_default: |-
+  {
+    {% for key, image in community_images.items() %}
+    {% if "kubernetes_version" in image %}
+    {% set kube_vn_no_prefix = image.kubernetes_version.removeprefix("v") %}
+    {% set kube_vn_dash = kube_vn_no_prefix | replace('.', '-') %}
+    "kube-{{ kube_vn_dash }}": {
+      "label": "{{ image.kubernetes_version }}",
+      "description": "Kubernetes {{ kube_vn_no_prefix }} with HA control plane.",
+      "values": {
+        "kubernetesVersion": "{{ kube_vn_no_prefix }}",
+        "machineImageId": "{{ community_images_image_ids[key] }}",
+        "clusterNetworking": {
+          "internalNetwork": {
+            "networkFilter": {
+              "tags": "portal-internal",
+            },
+          },
+        },
+      },
+    },
+    {% endif %}
+    {% endfor %}
+  }
 # Allow extra templates to be defined using a separate variable
 azimuth_capi_operator_cluster_templates_extra: {}
 # The full list of Kubernetes cluster templates to install

--- a/roles/azimuth_capi_operator/tasks/main.yml
+++ b/roles/azimuth_capi_operator/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Import community_images variable
+  import_role:
+    name: stackhpc.azimuth_ops.community_images
+    tasks_from: export_community_images.yml
+  when: community_images is not defined
+
 - name: Install Azimuth CAPI operator on target Kubernetes cluster
   kubernetes.core.helm:
     chart_ref: "{{ azimuth_capi_operator_chart_name }}"

--- a/roles/capi_cluster/defaults/main.yml
+++ b/roles/capi_cluster/defaults/main.yml
@@ -38,19 +38,16 @@ capi_cluster_openstack_ca_cert: >-
 # Default, wire these up with an image from community images when available
 capi_cluster_kubernetes_version: >-
   {{-
-    '1.25.8'
-    if (
-      community_images_image_ids is defined and
-      'kube_1_25_8' in community_images_image_ids
-    )
+    community_images.kube_1_26.kubernetes_version
+    if community_images is defined and 'kube_1_26' in community_images
     else undef(hint = 'capi_cluster_kubernetes_version is required')
   }}
 capi_cluster_machine_image_id: >-
   {{-
-    community_images_image_ids.kube_1_25_8
+    community_images_image_ids.kube_1_26
     if (
       community_images_image_ids is defined and
-      'kube_1_25_8' in community_images_image_ids
+      'kube_1_26' in community_images_image_ids
     )
     else undef(hint = 'capi_cluster_machine_image_id is required')
   }}

--- a/roles/capi_cluster/tasks/main.yml
+++ b/roles/capi_cluster/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Import community_images variable
+  import_role:
+    name: stackhpc.azimuth_ops.community_images
+    tasks_from: export_community_images.yml
+  when: community_images is not defined
+
 - block:
     - name: Install or upgrade cluster
       kubernetes.core.helm:

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -39,51 +39,50 @@ community_images_azimuth_images_manifest_url: >-
 community_images_azimuth_images_manifest: >-
   {{ lookup('url', community_images_azimuth_images_manifest_url, split_lines = False) | from_json }}
 
-# The default community images to upload
-# By default, we upload images for Kubernetes and CaaS appliances from azimuth-images
+# Generate community image specs for the images in the manifest
+# We don't use all the images
+community_images_azimuth_images: |-
+  {
+    {% for source_key, image in community_images_azimuth_images_manifest.items() %}
+    {% if "kubernetes_version" in image and source_key.endswith("-jammy") %}
+      {% set kube_version = image.kubernetes_version.removeprefix("v") %}
+      {% set kube_series = kube_version.split(".")[:-1] | join("_") %}
+      {% set dest_key = "kube_" ~ kube_series %}
+    {% elif source_key == "jupyter-repo2docker" %}
+      {% set dest_key = "repo2docker" %}
+    {% elif source_key == "ubuntu-desktop" %}
+      {% set dest_key = "workstation" %}
+    {% else %}
+      {% set dest_key = None %}
+    {% endif %}
+    {% if dest_key %}
+    "{{ dest_key }}": {
+      "name": "{{ image.name }}",
+      "source_url": "{{ image.url }}",
+      "checksum": "{{ image.checksum }}",
+      "source_disk_format": "qcow2",
+      "container_format": "bare",
+      {% if "kubernetes_version" in image %}
+      "kubernetes_version": "{{ image.kubernetes_version }}",
+      {% endif %}
+    },
+    {% endif %}
+    {% endfor %}
+  }
+
 # Slurm images are published by the slurm_image_builder repo - https://github.com/stackhpc/slurm_image_builder
-community_images_slurm_base_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images
-community_images_default:
-  # Images for Kubernetes
-  kube_1_25:
-    name: "{{ community_images_azimuth_images_manifest['kubernetes-1-25-jammy'].name }}"
-    source_url: "{{ community_images_azimuth_images_manifest['kubernetes-1-25-jammy'].url }}"
-    checksum: "{{ community_images_azimuth_images_manifest['kubernetes-1-25-jammy'].checksum }}"
-    source_disk_format: qcow2
-    container_format: bare
-    kubernetes_version: "{{ community_images_azimuth_images_manifest['kubernetes-1-25-jammy'].kubernetes_version }}"
-  kube_1_26:
-    name: "{{ community_images_azimuth_images_manifest['kubernetes-1-26-jammy'].name }}"
-    source_url: "{{ community_images_azimuth_images_manifest['kubernetes-1-26-jammy'].url }}"
-    checksum: "{{ community_images_azimuth_images_manifest['kubernetes-1-26-jammy'].checksum }}"
-    source_disk_format: qcow2
-    container_format: bare
-    kubernetes_version: "{{ community_images_azimuth_images_manifest['kubernetes-1-26-jammy'].kubernetes_version }}"
-  kube_1_27:
-    name: "{{ community_images_azimuth_images_manifest['kubernetes-1-27-jammy'].name }}"
-    source_url: "{{ community_images_azimuth_images_manifest['kubernetes-1-27-jammy'].url }}"
-    checksum: "{{ community_images_azimuth_images_manifest['kubernetes-1-27-jammy'].checksum }}"
-    source_disk_format: qcow2
-    container_format: bare
-    kubernetes_version: "{{ community_images_azimuth_images_manifest['kubernetes-1-27-jammy'].kubernetes_version }}"
-  # Images for CaaS appliances
-  repo2docker:
-    name: "{{ community_images_azimuth_images_manifest['jupyter-repo2docker'].name }}"
-    source_url: "{{ community_images_azimuth_images_manifest['jupyter-repo2docker'].url }}"
-    checksum: "{{ community_images_azimuth_images_manifest['jupyter-repo2docker'].checksum }}"
-    source_disk_format: qcow2
-    container_format: bare
-  workstation:
-    name: "{{ community_images_azimuth_images_manifest['ubuntu-desktop'].name }}"
-    source_url: "{{ community_images_azimuth_images_manifest['ubuntu-desktop'].url }}"
-    checksum: "{{ community_images_azimuth_images_manifest['ubuntu-desktop'].checksum }}"
-    source_disk_format: qcow2
-    container_format: bare
+community_images_slurm_base_url: >-
+  https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images
+community_images_slurm:
   openhpc:
     name: openhpc-230217-1440
     source_url: "{{ community_images_slurm_base_url }}/openhpc-230217-1440.qcow2"
     source_disk_format: qcow2
     container_format: bare
+
+# The default community images to upload
+community_images_default: >-
+  {{ community_images_azimuth_images | combine(community_images_slurm, recursive = True) }}
 
 # Any extra community images to upload as well as the defaults
 community_images_extra: {}

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -30,44 +30,53 @@ community_images_os_clouds_file: "{{ community_images_os_config_dir }}/clouds.ya
 # The disk format for the target cloud
 community_images_disk_format: qcow2
 
+# The version of azimuth-images to use to populate the default community images
+community_images_azimuth_images_version: 0.1.2
+# The azimuth-images manifest URL
+community_images_azimuth_images_manifest_url: >-
+  https://github.com/stackhpc/azimuth-images/releases/download/{{ community_images_azimuth_images_version }}/manifest.json
+# The azimuth-images manifest data
+community_images_azimuth_images_manifest: >-
+  {{ lookup('url', community_images_azimuth_images_manifest_url, split_lines = False) | from_json }}
+
 # The default community images to upload
-# By default, we upload images for Kubernetes and CaaS appliances
+# By default, we upload images for Kubernetes and CaaS appliances from azimuth-images
 # Slurm images are published by the slurm_image_builder repo - https://github.com/stackhpc/slurm_image_builder
-# All other images are published by the azimuth-images repo - https://github.com/stackhpc/azimuth-images
-# Images are hosted by UoC Arcus
-community_images_base_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_f0dc9cb312144d0aa44037c9149d2513/azimuth-images-prerelease
 community_images_slurm_base_url: https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images
 community_images_default:
   # Images for Kubernetes
-  kube_1_23_16:
-    name: ubuntu-focal-kube-v1.23.16-230411-1334
-    source_url: "{{ community_images_base_url }}/ubuntu-focal-kube-v1.23.16-230411-1334.qcow2"
+  kube_1_25:
+    name: "{{ community_images_azimuth_images_manifest['kubernetes-1-25-jammy'].name }}"
+    source_url: "{{ community_images_azimuth_images_manifest['kubernetes-1-25-jammy'].url }}"
+    checksum: "{{ community_images_azimuth_images_manifest['kubernetes-1-25-jammy'].checksum }}"
     source_disk_format: qcow2
     container_format: bare
-  kube_1_24_12:
-    name: ubuntu-focal-kube-v1.24.12-230411-1402
-    source_url: "{{ community_images_base_url }}/ubuntu-focal-kube-v1.24.12-230411-1402.qcow2"
+    kubernetes_version: "{{ community_images_azimuth_images_manifest['kubernetes-1-25-jammy'].kubernetes_version }}"
+  kube_1_26:
+    name: "{{ community_images_azimuth_images_manifest['kubernetes-1-26-jammy'].name }}"
+    source_url: "{{ community_images_azimuth_images_manifest['kubernetes-1-26-jammy'].url }}"
+    checksum: "{{ community_images_azimuth_images_manifest['kubernetes-1-26-jammy'].checksum }}"
     source_disk_format: qcow2
     container_format: bare
-  kube_1_25_8:
-    name: ubuntu-focal-kube-v1.25.8-230411-1429
-    source_url: "{{ community_images_base_url }}/ubuntu-focal-kube-v1.25.8-230411-1429.qcow2"
+    kubernetes_version: "{{ community_images_azimuth_images_manifest['kubernetes-1-26-jammy'].kubernetes_version }}"
+  kube_1_27:
+    name: "{{ community_images_azimuth_images_manifest['kubernetes-1-27-jammy'].name }}"
+    source_url: "{{ community_images_azimuth_images_manifest['kubernetes-1-27-jammy'].url }}"
+    checksum: "{{ community_images_azimuth_images_manifest['kubernetes-1-27-jammy'].checksum }}"
     source_disk_format: qcow2
     container_format: bare
-  kube_1_26_3:
-    name: ubuntu-focal-kube-v1.26.3-230411-1504
-    source_url: "{{ community_images_base_url }}/ubuntu-focal-kube-v1.26.3-230411-1504.qcow2"
-    source_disk_format: qcow2
-    container_format: bare
+    kubernetes_version: "{{ community_images_azimuth_images_manifest['kubernetes-1-27-jammy'].kubernetes_version }}"
   # Images for CaaS appliances
   repo2docker:
-    name: ubuntu-focal-jupyter-repo2docker-230411-1311
-    source_url: "{{ community_images_base_url }}/ubuntu-focal-jupyter-repo2docker-230411-1311.qcow2"
+    name: "{{ community_images_azimuth_images_manifest['jupyter-repo2docker'].name }}"
+    source_url: "{{ community_images_azimuth_images_manifest['jupyter-repo2docker'].url }}"
+    checksum: "{{ community_images_azimuth_images_manifest['jupyter-repo2docker'].checksum }}"
     source_disk_format: qcow2
     container_format: bare
   workstation:
-    name: ubuntu-focal-desktop-230411-1203
-    source_url: "{{ community_images_base_url }}/ubuntu-focal-desktop-230411-1203.qcow2"
+    name: "{{ community_images_azimuth_images_manifest['ubuntu-desktop'].name }}"
+    source_url: "{{ community_images_azimuth_images_manifest['ubuntu-desktop'].url }}"
+    checksum: "{{ community_images_azimuth_images_manifest['ubuntu-desktop'].checksum }}"
     source_disk_format: qcow2
     container_format: bare
   openhpc:

--- a/roles/community_images/tasks/export_community_images.yml
+++ b/roles/community_images/tasks/export_community_images.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Export community_images variable
+  set_fact:
+    community_images: "{{ community_images }}"

--- a/roles/community_images/tasks/upload_image.yml
+++ b/roles/community_images/tasks/upload_image.yml
@@ -80,6 +80,7 @@
       get_url:
         url: "{{ community_images_image_spec.source_url }}"
         dest: "{{ community_images_image_download_path }}"
+        checksum: "{{ community_images_image_spec.checksum | default(omit) }}"
         timeout: 600
 
     - name: "Uncompress image (bzip2) - {{ community_images_image_spec.name }}"


### PR DESCRIPTION
Add support for populating community images from azimuth-images manifests.

Kubernetes templates are also now generated from the available Kubernetes images.