### PR TITLE
Update caas-slurm git SHA to latest on main

### DIFF
--- a/roles/azimuth_caas_operator/defaults/main.yaml
+++ b/roles/azimuth_caas_operator/defaults/main.yaml
@@ -79,7 +79,7 @@ azimuth_caas_stackhpc_slurm_appliance_enabled: "{{ azimuth_clusters_enabled }}"
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/caas-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: cb0d7930c6ebf2fc8e21178b5a579b3e07cc726e
+azimuth_caas_stackhpc_slurm_appliance_git_version: b2333f3e45ec62fc185061930f43a108048c6d45
 # The playbook to use for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_playbook: slurm-infra.yml
 # The metadata root for the StackHPC Slurm appliance


### PR DESCRIPTION
Fixes failing checkout because https://github.com/stackhpc/caas-slurm-appliance/commit/cb0d7930c6ebf2fc8e21178b5a579b3e07cc726e no longer belongs to a branch.