### PR TITLE
Add chores to update dependencies

### DIFF
--- a/.github/scripts/github-update-version
+++ b/.github/scripts/github-update-version
@@ -39,7 +39,7 @@ repo = urllib.parse.urlsplit(repo_url).path.removeprefix("/")
 api_url = f"https://api.github.com/repos/{repo}/releases/latest"
 response = requests.get(api_url)
 response.raise_for_status()
-next_version = data[args.version_variable] = response.json()["name"]
+next_version = data[args.version_variable] = response.json()["tag_name"]
 
 with open(args.path, "w") as fh:
     yaml.dump(data, fh)

--- a/.github/scripts/helm-update-version
+++ b/.github/scripts/helm-update-version
@@ -55,7 +55,8 @@ for entry in entries:
         next_version = version
 
 # Update the version variable
-data[args.version_variable] = str(next_version)
+if next_version:
+    data[args.version_variable] = str(next_version)
 
 with open(args.path, "w") as fh:
     yaml.dump(data, fh)

--- a/.github/scripts/helm-update-version
+++ b/.github/scripts/helm-update-version
@@ -17,8 +17,7 @@ parser.add_argument("repo_variable", help = "The variable containing the Helm re
 parser.add_argument("chart_variable", help = "The variable containing the Helm chart.")
 parser.add_argument("version_variable", help = "The variable containing the version.")
 parser.add_argument(
-    "--constraints",
-    default = ">=0.0.0",
+    "constraints",
     help = "Comma-separated list of constraints to apply when considering versions."
 )
 args = parser.parse_args()

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,12 +14,30 @@ jobs:
         include:
           - component: cert-manager
             type: helm
+            path: ./roles/certmanager/defaults/main.yml
+            repo_variable: certmanager_chart_repo
+            chart_variable: certmanager_chart_name
+            version_variable: certmanager_chart_version
+            constraints: "<=v1.12.2"
     name: ${{ matrix.component }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Install script dependencies
+        run: pip install -r .github/scripts/requirements.txt
+
+      - name: Check for updates
+        run: >
+          .github/scripts/helm-update-version
+            ${{ matrix.path }}
+            ${{ matrix.repo_variable }}
+            ${{ matrix.chart_variable }}
+            ${{ matrix.version_variable }}
+            '${{ matrix.constraints }}'
+        if: ${{ matrix.type == 'helm' }}
       
-      - name: Propose changes via PR
+      - name: Propose changes via PR if required
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: Update ${{ matrix.component }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -18,6 +18,13 @@ jobs:
             repo_variable: certmanager_chart_repo
             chart_variable: certmanager_chart_name
             version_variable: certmanager_chart_version
+
+          - component: cluster-api
+            type: github
+            path: ./roles/clusterapi/defaults/main.yml
+            repo_variable: clusterapi_core_repo
+            version_variable: clusterapi_core_version
+
     name: ${{ matrix.component }}
     steps:
       - name: Checkout
@@ -26,7 +33,7 @@ jobs:
       - name: Install script dependencies
         run: pip install -r .github/scripts/requirements.txt
 
-      - name: Check for updates
+      - name: Check for updates (Helm)
         id: helm-update-version
         run: |
           .github/scripts/helm-update-version \
@@ -37,6 +44,15 @@ jobs:
             '${{ matrix.constraints || '>=0.0.0' }}'
         if: ${{ matrix.type == 'helm' }}
 
+      - name: Check for updates (GitHub)
+        id: github-update-version
+        run: |
+          .github/scripts/github-update-version \
+            ${{ matrix.path }} \
+            ${{ matrix.repo_variable }} \
+            ${{ matrix.version_variable }}
+        if: ${{ matrix.type == 'github' }}
+
       - name: Get next version from relevant outputs
         id: next
         run: >-
@@ -45,7 +61,8 @@ jobs:
           NEXT_VERSION: >-
             ${{
               matrix.type == 'helm' &&
-              steps.helm-update-version.outputs.next-version
+              steps.helm-update-version.outputs.next-version ||
+              steps.github-update-version.outputs.next-version
             }}
 
       - name: Propose changes via PR if required

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -18,7 +18,6 @@ jobs:
             repo_variable: certmanager_chart_repo
             chart_variable: certmanager_chart_name
             version_variable: certmanager_chart_version
-            constraints: "<=v1.12.2"
     name: ${{ matrix.component }}
     steps:
       - name: Checkout
@@ -28,25 +27,38 @@ jobs:
         run: pip install -r .github/scripts/requirements.txt
 
       - name: Check for updates
+        id: helm-update-version
         run: |
           .github/scripts/helm-update-version \
             ${{ matrix.path }} \
             ${{ matrix.repo_variable }} \
             ${{ matrix.chart_variable }} \
             ${{ matrix.version_variable }} \
-            '${{ matrix.constraints }}'
+            '${{ matrix.constraints || '>=0.0.0' }}'
         if: ${{ matrix.type == 'helm' }}
-      
+
+      - name: Get next version from relevant outputs
+        id: next
+        run: >-
+          echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+        env:
+          NEXT_VERSION: >-
+            ${{
+              matrix.type == 'helm' &&
+              steps.helm-update-version.outputs.next-version
+            }}
+
       - name: Propose changes via PR if required
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: Update ${{ matrix.component }}
+          commit-message: >-
+            Update ${{ matrix.component }} to ${{ steps.next.outputs.version }}
           branch: update/${{ matrix.component }}
           delete-branch: true
-          title: Update ${{ matrix.component }}
+          title: Update ${{ matrix.component }} to ${{ steps.next.outputs.version }}
           body: >
             This PR was created automatically to update
-            ${{ matrix.component }}.
+            ${{ matrix.component }} to ${{ steps.next.outputs.version }}.
           labels: |
             automation
             dependency-update

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -28,12 +28,12 @@ jobs:
         run: pip install -r .github/scripts/requirements.txt
 
       - name: Check for updates
-        run: >
-          .github/scripts/helm-update-version
-            ${{ matrix.path }}
-            ${{ matrix.repo_variable }}
-            ${{ matrix.chart_variable }}
-            ${{ matrix.version_variable }}
+        run: |
+          .github/scripts/helm-update-version \
+            ${{ matrix.path }} \
+            ${{ matrix.repo_variable }} \
+            ${{ matrix.chart_variable }} \
+            ${{ matrix.version_variable }} \
             '${{ matrix.constraints }}'
         if: ${{ matrix.type == 'helm' }}
       

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -3,8 +3,8 @@ on:
   # Allow manual executions
   workflow_dispatch:
   # Run nightly
-  # schedule:
-  #   - cron: '0 0 * * *'
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   propose_update_pr:
@@ -12,6 +12,62 @@ jobs:
     strategy:
       matrix:
         include:
+          - component: azimuth
+            type: helm
+            path: ./roles/azimuth/defaults/main.yml
+            repo_variable: azimuth_chart_repo
+            chart_variable: azimuth_chart_name
+            version_variable: azimuth_chart_version
+            # For now, use builds for main
+            # TODO(mkjpryor) Remove this constraint to use stable versions only
+            constraints: ">=0.1.0-dev.0.main.0,<0.1.0-dev.0.main.999999999"
+
+          - component: azimuth-caas-operator
+            type: helm
+            path: ./roles/azimuth_caas_operator/defaults/main.yml
+            repo_variable: azimuth_caas_operator_chart_repo
+            chart_variable: azimuth_caas_operator_chart_name
+            version_variable: azimuth_caas_operator_chart_version
+            # For now, use builds for main
+            # TODO(mkjpryor) Remove this constraint to use stable versions only
+            constraints: ">=0.2.3-dev.0.main.0,<0.2.3-dev.0.main.999999999"
+
+          - component: azimuth-capi-operator
+            type: helm
+            path: ./roles/azimuth_capi_operator/defaults/main.yml
+            repo_variable: azimuth_capi_operator_chart_repo
+            chart_variable: azimuth_capi_operator_chart_name
+            version_variable: azimuth_capi_operator_chart_version
+            # For now, use builds for main
+            # TODO(mkjpryor) Remove this constraint to use stable versions only
+            constraints: ">=0.1.0-dev.0.main.0,<0.1.0-dev.0.main.999999999"
+
+          - component: azimuth-identity-operator
+            type: helm
+            path: ./roles/azimuth_identity_operator/defaults/main.yml
+            repo_variable: azimuth_identity_operator_chart_repo
+            chart_variable: azimuth_identity_operator_chart_name
+            version_variable: azimuth_identity_operator_chart_version
+            # For now, use builds for main
+            # TODO(mkjpryor) Remove this constraint to use stable versions only
+            constraints: ">=0.1.0-dev.0.main.0,<0.1.0-dev.0.main.999999999"
+
+          - component: azimuth-images
+            type: github
+            path: ./roles/community_images/defaults/main.yml
+            repo_variable: community_images_azimuth_images_repo
+            version_variable: community_images_azimuth_images_version
+
+          - component: capi-helm-openstack-cluster
+            type: helm
+            path: ./roles/capi_cluster/defaults/main.yml
+            repo_variable: capi_cluster_chart_repo
+            chart_variable: capi_cluster_chart_name
+            version_variable: capi_cluster_chart_version
+            # For now, use builds for main
+            # TODO(mkjpryor) Remove this constraint to use stable versions only
+            constraints: ">=0.1.2-dev.0.main.0,<0.1.2-dev.0.main.999999999"
+
           - component: cert-manager
             type: helm
             path: ./roles/certmanager/defaults/main.yml
@@ -19,11 +75,87 @@ jobs:
             chart_variable: certmanager_chart_name
             version_variable: certmanager_chart_version
 
+          - component: cloud-metrics-grafana
+            type: helm
+            path: ./roles/cloud_metrics/defaults/main.yml
+            repo_variable: cloud_metrics_grafana_chart_repo
+            chart_variable: cloud_metrics_grafana_chart_name
+            version_variable: cloud_metrics_grafana_chart_version
+
           - component: cluster-api
             type: github
             path: ./roles/clusterapi/defaults/main.yml
             repo_variable: clusterapi_core_repo
             version_variable: clusterapi_core_version
+
+          - component: cluster-api-provider-openstack
+            type: github
+            path: ./roles/clusterapi/defaults/main.yml
+            repo_variable: clusterapi_openstack_repo
+            version_variable: clusterapi_openstack_version
+
+          - component: cluster-api-addon-provider
+            type: helm
+            path: ./roles/clusterapi/defaults/main.yml
+            repo_variable: clusterapi_addon_provider_chart_repo
+            chart_variable: clusterapi_addon_provider_chart_name
+            version_variable: clusterapi_addon_provider_chart_version
+
+          - component: consul
+            type: helm
+            path: ./roles/consul/defaults/main.yml
+            repo_variable: consul_chart_repo
+            chart_variable: consul_chart_name
+            version_variable: consul_chart_version
+
+          - component: harbor
+            type: helm
+            path: ./roles/harbor/defaults/main.yml
+            repo_variable: harbor_chart_repo
+            chart_variable: harbor_chart_name
+            version_variable: harbor_chart_version
+
+          - component: helm
+            type: github
+            path: ./roles/helm/defaults/main.yml
+            repo_variable: helm_repo
+            version_variable: helm_version
+
+          - component: ingress-nginx
+            type: helm
+            path: ./roles/ingress_nginx/defaults/main.yml
+            repo_variable: ingress_nginx_chart_repo
+            chart_variable: ingress_nginx_chart_name
+            version_variable: ingress_nginx_chart_version
+
+          - component: k3s
+            type: github
+            path: ./roles/k3s/defaults/main.yml
+            repo_variable: k3s_repo
+            version_variable: k3s_version
+
+          - component: kube-prometheus-stack
+            type: helm
+            path: ./roles/kube_prometheus_stack/defaults/main.yml
+            repo_variable: kube_prometheus_stack_chart_repo
+            chart_variable: kube_prometheus_stack_chart_name
+            version_variable: kube_prometheus_stack_chart_version
+
+          - component: kustomize
+            type: github
+            path: ./roles/kustomize/defaults/main.yml
+            repo_variable: kustomize_repo
+            version_variable: kustomize_version
+
+          - component: zenith
+            type: helm
+            path: ./roles/zenith/defaults/main.yml
+            repo_variable: zenith_chart_repo
+            chart_variable: zenith_chart_name
+            version_variable: zenith_chart_version
+            # For now, use builds for main
+            # TODO(mkjpryor) Remove this constraint to use stable versions only
+            constraints: ">=0.1.0-dev.0.main.0,<0.1.0-dev.0.main.999999999"
 
     name: ${{ matrix.component }}
     steps:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -55,11 +55,11 @@ jobs:
             Update ${{ matrix.component }} to ${{ steps.next.outputs.version }}
           branch: update/${{ matrix.component }}
           delete-branch: true
-          title: Update ${{ matrix.component }} to ${{ steps.next.outputs.version }}
+          title: >-
+            Update ${{ matrix.component }} to ${{ steps.next.outputs.version }}
           body: >
             This PR was created automatically to update
             ${{ matrix.component }} to ${{ steps.next.outputs.version }}.
           labels: |
             automation
             dependency-update
-          draft: true

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           commit-message: Update ${{ matrix.component }}
           branch: update/${{ matrix.component }}
-          delete-branch: yes
+          delete-branch: true
           title: Update ${{ matrix.component }}
           body: >
             This PR was created automatically to update


### PR DESCRIPTION
This covers all dependencies that can be updated by checking a Helm repo or GitHub releases.

A couple of weird ones remain - Keycloak operator and Postgres operator. Postgres operator now has a Helm chart that we can move to, but it is stored in an OCI repo so would need different code to check the available tags (this is also subject to migrating from the existing kustomize-based install).