### PR TITLE
Revert to focal images for Kubernetes

### DIFF
--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -46,7 +46,7 @@ community_images_azimuth_images_manifest: >-
 community_images_azimuth_images: |-
   {
     {% for source_key, image in community_images_azimuth_images_manifest.items() %}
-    {% if "kubernetes_version" in image and source_key.endswith("-jammy") %}
+    {% if "kubernetes_version" in image and source_key.endswith("-focal") %}
       {% set kube_version = image.kubernetes_version.removeprefix("v") %}
       {% set kube_series = kube_version.split(".")[:-1] | join("_") %}
       {% set dest_key = "kube_" ~ kube_series %}


### PR DESCRIPTION
Jammy images work, but have issues with Harbor that need to be investigated further (maybe down to differing containerd versions?). 

For now, we revert to focal images until the issues can be bottomed out. 