### PR TITLE
Add config option for seed network MTU

### DIFF
--- a/roles/infra/defaults/main.yml
+++ b/roles/infra/defaults/main.yml
@@ -22,6 +22,9 @@ infra_network_id:
 # OR
 # The CIDR of the subnet that should be created
 infra_network_cidr: 192.168.100.0/24
+# The MTU of the internal network that should be created
+# (will be set to cloud default if left undefined)
+infra_network_mtu: 
 # The ID of the external network to connect to via a router
 infra_external_network_id: >-
   {{-

--- a/roles/infra/templates/resources.tf.j2
+++ b/roles/infra/templates/resources.tf.j2
@@ -33,6 +33,9 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_ingress_{{ port_
 resource "openstack_networking_network_v2" "internal_net" {
   name           = "{{ infra_name }}"
   admin_state_up = "true"
+  {% if infra_network_mtu %}
+  mtu = "{{ infra_network_mtu }}"
+  {% endif %}
 }
 
 resource "openstack_networking_subnet_v2" "internal_subnet" {


### PR DESCRIPTION
On clouds where Neutron is configured to assign a default MTU of 9000 to internal networks and where the OVN Octavia driver is in use for load balancers, the MTU mismatch between these internal networks and a 1500 MTU external network can cause issues with the NGINX Ingress LB for HA Azimuths deployments. Specifically, we find that loading the Azimuth web UI hangs when trying to fetch a large `bundle.js` file, but the web page can be fetched successfully with curl (because that doesn't pull in all the JS). The simplest fix for this seems to be forcing the seed network to have an MTU of 1500. Other networks with 9000 MTU (e.g. `portal-internal` networks created in other projects) apparently don't cause issues so this is the only change needed.