### PR TITLE
Remove admin role from application credential

### DIFF
--- a/roles/azimuth/defaults/main.yml
+++ b/roles/azimuth/defaults/main.yml
@@ -3,7 +3,7 @@
 # The chart to use
 azimuth_chart_repo: https://stackhpc.github.io/azimuth
 azimuth_chart_name: azimuth
-azimuth_chart_version: 0.1.0-dev.0.master.760
+azimuth_chart_version: 0.1.0-dev.0.master.761
 
 # Release information for the Azimuth release
 azimuth_release_namespace: azimuth
@@ -15,7 +15,7 @@ azimuth_wait_timeout: 10m
 # Feature flags
 #   Indicates if the app proxy should be enabled
 azimuth_apps_enabled: yes
-#   Indicates if Cluster-as-a-Service should be enabled 
+#   Indicates if Cluster-as-a-Service should be enabled
 azimuth_clusters_enabled: yes
 #   Indicates if Kubernetes clusters should be enabled
 azimuth_kubernetes_enabled: yes
@@ -356,7 +356,7 @@ azimuth_release_defaults:
         "queryParams": azimuth_apps_query_params,
       }
       if azimuth_apps_enabled
-      else {}        
+      else {}
     }}
   theme: >-
     {{-


### PR DESCRIPTION
https://github.com/stackhpc/azimuth/pull/65


also removed trailing whitespaces:
`<stdin>:9: trailing whitespace.
#   Indicates if Cluster-as-a-Service should be enabled
<stdin>:18: trailing whitespace.
      else {}
warning: 2 lines add whitespace errors.`