### PR TITLE
Bump azimuth-images to next true tag

### DIFF
--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -33,7 +33,7 @@ community_images_disk_format: qcow2
 # The repository to use for azimuth-images
 community_images_azimuth_images_repo: https://github.com/stackhpc/azimuth-images
 # The version of azimuth-images to use to populate the default community images
-community_images_azimuth_images_version: 0.4.0
+community_images_azimuth_images_version: 0.3.0
 # The azimuth-images manifest URL
 community_images_azimuth_images_manifest_url: >-
   {{ community_images_azimuth_images_repo }}/releases/download/{{ community_images_azimuth_images_version }}/manifest.json


### PR DESCRIPTION
NOTE: The tag appears to go backwards because pre-release tags that do not follow the pre-release convention have been removed.