### PR TITLE
Version bumps of StackHPC-authored components for release

### DIFF
--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -2,7 +2,7 @@
 # The chart to use
 azimuth_caas_operator_chart_repo: https://stackhpc.github.io/azimuth-caas-operator
 azimuth_caas_operator_chart_name: azimuth-caas-operator
-azimuth_caas_operator_chart_version: 0.2.3-dev.0.main.12
+azimuth_caas_operator_chart_version: 0.3.1-dev.0.main.2
 
 # Release information for the operator release
 # Use the same namespace as Azimuth by default

--- a/roles/azimuth_capi_operator/defaults/main.yml
+++ b/roles/azimuth_capi_operator/defaults/main.yml
@@ -3,7 +3,7 @@
 # The chart to use
 azimuth_capi_operator_chart_repo: https://stackhpc.github.io/azimuth-capi-operator
 azimuth_capi_operator_chart_name: azimuth-capi-operator
-azimuth_capi_operator_chart_version: 0.1.0-dev.0.main.137
+azimuth_capi_operator_chart_version: 0.1.0-dev.0.main.138
 
 # Release information for the CAPI operator release
 # Use the same namespace as Azimuth by default

--- a/roles/azimuth_identity_operator/defaults/main.yml
+++ b/roles/azimuth_identity_operator/defaults/main.yml
@@ -3,7 +3,7 @@
 # The chart to use
 azimuth_identity_operator_chart_repo: https://stackhpc.github.io/azimuth-identity-operator
 azimuth_identity_operator_chart_name: azimuth-identity-operator
-azimuth_identity_operator_chart_version: 0.1.0-dev.0.main.16
+azimuth_identity_operator_chart_version: 0.1.0-dev.0.main.17
 
 # Release information for the operator release
 # Use the same namespace as Azimuth by default

--- a/roles/capi_cluster/defaults/main.yml
+++ b/roles/capi_cluster/defaults/main.yml
@@ -3,7 +3,7 @@
 # The chart to use
 capi_cluster_chart_repo: https://stackhpc.github.io/capi-helm-charts
 capi_cluster_chart_name: openstack-cluster
-capi_cluster_chart_version: 0.1.3
+capi_cluster_chart_version: 0.1.4
 
 # Release information for the cluster release
 capi_cluster_release_namespace: default

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -46,7 +46,7 @@ community_images_azimuth_images_manifest: >-
 community_images_azimuth_images: |-
   {
     {% for source_key, image in community_images_azimuth_images_manifest.items() %}
-    {% if "kubernetes_version" in image and source_key.endswith("-focal") %}
+    {% if "kubernetes_version" in image and source_key.endswith("-jammy") %}
       {% set kube_version = image.kubernetes_version.removeprefix("v") %}
       {% set kube_series = kube_version.split(".")[:-1] | join("_") %}
       {% set dest_key = "kube_" ~ kube_series %}

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -33,7 +33,7 @@ community_images_disk_format: qcow2
 # The repository to use for azimuth-images
 community_images_azimuth_images_repo: https://github.com/stackhpc/azimuth-images
 # The version of azimuth-images to use to populate the default community images
-community_images_azimuth_images_version: 0.4.0
+community_images_azimuth_images_version: 0.3.0
 # The azimuth-images manifest URL
 community_images_azimuth_images_manifest_url: >-
   {{ community_images_azimuth_images_repo }}/releases/download/{{ community_images_azimuth_images_version }}/manifest.json

--- a/roles/infra/defaults/main.yml
+++ b/roles/infra/defaults/main.yml
@@ -69,9 +69,9 @@ infra_floatingip_pool:
 infra_image_id:
 # OR
 # The name of the image to upload (should be changed when the image changes)
-infra_image_name: ubuntu-focal-20230209
+infra_image_name: ubuntu-focal-20231011
 # The source URL for the image
-infra_image_source_url: https://cloud-images.ubuntu.com/releases/focal/release-20230209/ubuntu-20.04-server-cloudimg-amd64.img
+infra_image_source_url: https://cloud-images.ubuntu.com/releases/focal/release-20231011/ubuntu-20.04-server-cloudimg-amd64.img
 # The disk format of the image as downloaded
 infra_image_source_disk_format: qcow2
 # The container format for the image


### PR DESCRIPTION
Note that the azimuth-images tag appears to go backwards because pre-release tags that did not follow the pre-release convention have been removed.