### PR TITLE
Update caas_operator to v0.5.0

### DIFF
--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -2,7 +2,7 @@
 # The chart to use
 azimuth_caas_operator_chart_repo: https://stackhpc.github.io/azimuth-caas-operator
 azimuth_caas_operator_chart_name: azimuth-caas-operator
-azimuth_caas_operator_chart_version: 0.4.1
+azimuth_caas_operator_chart_version: 0.5.0
 
 # Release information for the operator release
 # Use the same namespace as Azimuth by default


### PR DESCRIPTION
This has a smaller docker container, but importantly fixes to making the parsing of outputs more robust.