### PR TITLE
Disable irrelevant prometheus alerts when not HA

### DIFF
--- a/roles/kube_prometheus_stack/defaults/main.yml
+++ b/roles/kube_prometheus_stack/defaults/main.yml
@@ -14,6 +14,12 @@ kube_prometheus_stack_wait_timeout: 10m
 
 # The values for the kube-prometheus-stack release
 kube_prometheus_stack_release_defaults:
+  defaultRules:
+    disabled:
+      # None of these are relevant in k3s context
+      KubeSchedulerDown: true
+      KubeProxyDown: true
+      KubeControllerManagerDown: true
   prometheus:
     prometheusSpec:
       podMonitorSelectorNilUsesHelmValues: false
@@ -37,7 +43,9 @@ kube_prometheus_stack_release_defaults:
       # Do NOT add the namespace matcher to routes from AlertmanagerConfig resources
       alertmanagerConfigMatcherStrategy:
         type: None
+
 kube_prometheus_stack_release_overrides: {}
+
 kube_prometheus_stack_release_values: >-
   {{-
     kube_prometheus_stack_release_defaults |


### PR DESCRIPTION
K3s doesn't have standalone versions of some Kubernetes components that are alerted on by the default kube-prometheus-stack Prometheus rules. Disabled these alerts if running on k3s.