### PR TITLE
Revert ingress-nginx update

### DIFF
--- a/roles/ingress_nginx/defaults/main.yml
+++ b/roles/ingress_nginx/defaults/main.yml
@@ -3,7 +3,7 @@
 # The chart to use
 ingress_nginx_chart_repo: https://kubernetes.github.io/ingress-nginx
 ingress_nginx_chart_name: ingress-nginx
-ingress_nginx_chart_version: 4.8.4
+ingress_nginx_chart_version: 4.8.3
 
 # Release information for the NGINX ingress controller release
 ingress_nginx_release_namespace: ingress-nginx


### PR DESCRIPTION
Version 4.8.4 was revoked by the ingress-nginx project. 