### PR TITLE
Update slurm appliance to v1.138

### DIFF
--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -79,7 +79,7 @@ azimuth_caas_stackhpc_slurm_appliance_enabled: "{{ azimuth_clusters_enabled }}"
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/ansible-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: v1.137
+azimuth_caas_stackhpc_slurm_appliance_git_version: v1.138
 # The playbook to use for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_playbook: ansible/site.yml
 # The metadata root for the StackHPC Slurm appliance

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -79,8 +79,8 @@ community_images_slurm_base_url: >-
   https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images
 community_images_slurm:
   openhpc:
-    name: openhpc-231206-1648-9d6aa4e4 # https://github.com/stackhpc/ansible-slurm-appliance/pull/340
-    source_url: "{{ community_images_slurm_base_url }}/openhpc-231020-1357-b5d8b056"
+    name: openhpc-240102-1025-e533fd70 # https://github.com/stackhpc/ansible-slurm-appliance/pull/346
+    source_url: "{{ community_images_slurm_base_url }}/openhpc-240102-1025-e533fd70"
     source_disk_format: qcow2
     container_format: bare
 


### PR DESCRIPTION
See [v1.138](https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.138)