### PR TITLE
Revert harbor to 1.13.1

### DIFF
--- a/roles/harbor/defaults/main.yml
+++ b/roles/harbor/defaults/main.yml
@@ -3,7 +3,7 @@
 # The Harbor chart to use
 harbor_chart_repo: https://helm.goharbor.io
 harbor_chart_name: harbor
-harbor_chart_version: 1.14.0
+harbor_chart_version: 1.13.1
 
 # Release information for the Harbor release
 harbor_release_namespace: harbor


### PR DESCRIPTION
This reverts commit fd1baabbc817c0bcff6d7582074a37496bf4e773.

This is required until https://github.com/goharbor/harbor-helm/pull/1675 merges.