### PR TITLE
Make whether slurm uses manila for home an explicit opt-in

### DIFF
--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -82,11 +82,13 @@ azimuth_caas_stackhpc_slurm_appliance_enabled: "{{ azimuth_clusters_enabled }}"
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/ansible-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: v1.141
+azimuth_caas_stackhpc_slurm_appliance_git_version: fix/caas-cinder-home # TODO: bump on release
 # The playbook to use for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_playbook: ansible/site.yml
 # The timeout to apply to the k8s jobs which create, update & delete platform instances
 azimuth_caas_stackhpc_slurm_appliance_job_timeout_seconds: 1800
+# Whether to use manila shares for home directories:
+azimuth_caas_stackhpc_slurm_appliance_home_manila_share: false
 # The metadata root for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_metadata_url: >-
   https://raw.githubusercontent.com/stackhpc/ansible-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/environments/.caas/ui-meta/slurm-infra.yml
@@ -113,6 +115,7 @@ azimuth_caas_stackhpc_slurm_appliance_image: >-
 # The default extra vars for templates in the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_extra_vars_defaults:
   cluster_image: "{{ azimuth_caas_stackhpc_slurm_appliance_image }}"
+  cluster_home_manila_share: "{{ azimuth_caas_stackhpc_slurm_appliance_home_manila_share }}"
 # extra_vars overrides for templates in the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_extra_vars_overrides: {}
 azimuth_caas_stackhpc_slurm_appliance_extra_vars: >-

--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -82,7 +82,7 @@ azimuth_caas_stackhpc_slurm_appliance_enabled: "{{ azimuth_clusters_enabled }}"
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/ansible-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: fix/caas-cinder-home # TODO: bump on release
+azimuth_caas_stackhpc_slurm_appliance_git_version: v1.142
 # The playbook to use for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_playbook: ansible/site.yml
 # The timeout to apply to the k8s jobs which create, update & delete platform instances

--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -89,9 +89,11 @@ azimuth_caas_stackhpc_slurm_appliance_playbook: ansible/site.yml
 azimuth_caas_stackhpc_slurm_appliance_job_timeout_seconds: 1800
 # Whether to use manila shares for home directories:
 azimuth_caas_stackhpc_slurm_appliance_home_manila_share: false
+# The metadata file for the StackHPC Slurm appliance
+azimuth_caas_stackhpc_slurm_appliance_metadata_file: "{{ 'slurm-infra-manila-home.yml' if azimuth_caas_stackhpc_slurm_appliance_home_manila_share else 'slurm-infra.yml' }}"
 # The metadata root for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_metadata_url: >-
-  https://raw.githubusercontent.com/stackhpc/ansible-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/environments/.caas/ui-meta/slurm-infra.yml
+  https://raw.githubusercontent.com/stackhpc/ansible-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/environments/.caas/ui-meta/{{ azimuth_caas_stackhpc_slurm_appliance_metadata_file }}
 # The ID of the image to use with the StackHPC Slurm appliance
 # Support the old name for backwards compatibility
 # By default, use the openhpc image from community images if available


### PR DESCRIPTION
Adds a new variable `azimuth_caas_stackhpc_slurm_appliance_home_manila_share`, defaulting to false, to control whether Slurm CaaS clusters use manila shares for home, independent of whether project manila shares are enabled.

It also automatically switches the ui-meta file between the versions for home on cinder to home on manila, which ensures labels aren't misleading and quota is correctly calculated.

This prevents dataloss in the situation where:
- Deploy default Azimuth without project shares
- Deploy a Slurm cluster - gets Cinder home
- Enable the project share support in Azimuth
- Patch the Slurm cluster - without this PR existing data in /home gets deleted

Note that setting this variable true **will** result in data in /home being lost when existing Slurm clusters are patched or updated.