### PR TITLE
Feat/caas template deploy

### DIFF
--- a/playbooks/provision_cluster.yml
+++ b/playbooks/provision_cluster.yml
@@ -9,6 +9,7 @@
     - stackhpc.azimuth_ops.infra
   vars:
     infra_ansible_groups: [k3s, azimuth_deploy]
+  tags: only_install_caas_templates
 
 
 # Configure the node as a K3S cluster
@@ -87,11 +88,11 @@
         # Install the Velero components on the capi cluster and configure the backup schedule
         # NOTE(sd109): Need to use block so that we can set `environment` variables
         - block:
-          - include_role:
-              name: stackhpc.azimuth_ops.velero
-              tasks_from: schedule.yml
+            - include_role:
+                name: stackhpc.azimuth_ops.velero
+                tasks_from: schedule.yml
           environment:
             KUBECONFIG: "{{ ansible_env.HOME }}/kubeconfig-{{ capi_cluster_release_name }}.yaml"
           when: velero_enabled
-  
+
       when: install_mode == 'ha'

--- a/roles/azimuth_caas_operator/tasks/main.yaml
+++ b/roles/azimuth_caas_operator/tasks/main.yaml
@@ -1,4 +1,3 @@
----
 
 - name: Install Azimuth CaaS operator on target Kubernetes cluster
   kubernetes.core.helm:
@@ -32,6 +31,7 @@
   loop_control:
     loop_var: template
     label: "{{ template.name }}"
+  tag: only_install_caas_templates
 
 - name: Update secrets for Azimuth CaaS ssh key
   command: kubectl apply -f -

--- a/roles/azimuth_caas_operator/tasks/main.yaml
+++ b/roles/azimuth_caas_operator/tasks/main.yaml
@@ -31,7 +31,7 @@
   loop_control:
     loop_var: template
     label: "{{ template.name }}"
-  tag: only_install_caas_templates
+  tags: only_install_caas_templates
 
 - name: Update secrets for Azimuth CaaS ssh key
   command: kubectl apply -f -


### PR DESCRIPTION
Add Ansible tag `only_install_caas_templates`to two tasks, enabling faster rollout of just the CaaS templates,