### PR TITLE
Fix velero install

### DIFF
--- a/roles/velero/defaults/main.yml
+++ b/roles/velero/defaults/main.yml
@@ -64,7 +64,7 @@ velero_release_defaults:
   configuration:
     backupsEnabled: true
     backupStorageLocation:
-      - name: s3
+      - name: default
         default: true
         provider: aws
         bucket: "{{ velero_bucket_name }}"


### PR DESCRIPTION
It seems that a recent Velero release bumped the image tag for the Velero operator from v.1.12.X to v1.13.0 and this causes our Velero Helm chart installation to fail as the operator enters a crash loop. Apparently the new operator expects a BackupStorageLocation called 'default' to exist (rather than just one with `spec.default: true`). This change fixes the issue for now and https://github.com/stackhpc/azimuth-config/pull/109 should help to catch installation issues like this sooner, until we add a full backup and restore CI test.