### PR TITLE
Replace removeprefix with regex_replace

### DIFF
--- a/roles/azimuth_capi_operator/defaults/main.yml
+++ b/roles/azimuth_capi_operator/defaults/main.yml
@@ -481,7 +481,7 @@ azimuth_capi_operator_cluster_templates_default: |-
   {
     {% for key, image in community_images.items() %}
     {% if "kubernetes_version" in image %}
-    {% set kube_vn_no_prefix = image.kubernetes_version.removeprefix("v") %}
+    {% set kube_vn_no_prefix = image.kubernetes_version | regex_replace('^v', '') %}
     {% set kube_vn_dash = kube_vn_no_prefix | replace('.', '-') %}
     "kube-{{ kube_vn_dash }}": {
       "annotations": {{ azimuth_capi_operator_cluster_template_annotations }},

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -47,7 +47,7 @@ community_images_azimuth_images: |-
   {
     {% for source_key, image in community_images_azimuth_images_manifest.items() %}
     {% if "kubernetes_version" in image and source_key.endswith("-jammy") %}
-      {% set kube_version = image.kubernetes_version.removeprefix("v") %}
+      {% set kube_version = image.kubernetes_version | regex_replace('^v', '') %}
       {% set kube_series = kube_version.split(".")[:-1] | join("_") %}
       {% set dest_key = "kube_" ~ kube_series %}
     {% elif source_key == "jupyter-repo2docker" %}


### PR DESCRIPTION
Python 3.9 is required for the `removeprefix()` method, whereas `regex_replace()` is shipped as part of ansible.builtin and works with Python 3.8.