### PR TITLE
Bump slurm to v1.144 with RL8 and RL9 images

### DIFF
--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -82,7 +82,7 @@ azimuth_caas_stackhpc_slurm_appliance_enabled: "{{ azimuth_clusters_enabled }}"
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/ansible-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: v1.143
+azimuth_caas_stackhpc_slurm_appliance_git_version: v1.144
 # The playbook to use for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_playbook: ansible/site.yml
 # The timeout to apply to the k8s jobs which create, update & delete platform instances
@@ -96,17 +96,17 @@ azimuth_caas_stackhpc_slurm_appliance_metadata_url: >-
   https://raw.githubusercontent.com/stackhpc/ansible-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/environments/.caas/ui-meta/{{ azimuth_caas_stackhpc_slurm_appliance_metadata_file }}
 # The ID of the image to use with the StackHPC Slurm appliance
 # Support the old name for backwards compatibility
-# By default, use the openhpc image from community images if available
+# By default, use the openhpc_v3 (RockyLinyux 9) image from community images if available
 azimuth_caas_stackhpc_slurm_appliance_image: >-
   {{-
     azimuth_caas_stackhpc_slurm_appliance_rocky8_image
     if azimuth_caas_stackhpc_slurm_appliance_rocky8_image is defined
     else (
       (
-        community_images_image_ids.openhpc
+        community_images_image_ids.openhpc_v3
         if (
           community_images_image_ids is defined and
-          'openhpc' in community_images_image_ids
+          'openhpc_v3' in community_images_image_ids
         )
         else undef(hint = 'azimuth_caas_stackhpc_slurm_appliance_image is required')
       )

--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -96,17 +96,17 @@ azimuth_caas_stackhpc_slurm_appliance_metadata_url: >-
   https://raw.githubusercontent.com/stackhpc/ansible-slurm-appliance/{{ azimuth_caas_stackhpc_slurm_appliance_git_version }}/environments/.caas/ui-meta/{{ azimuth_caas_stackhpc_slurm_appliance_metadata_file }}
 # The ID of the image to use with the StackHPC Slurm appliance
 # Support the old name for backwards compatibility
-# By default, use the openhpc_v3 (RockyLinyux 9) image from community images if available
+# By default, use the openhpc image from community images if available
 azimuth_caas_stackhpc_slurm_appliance_image: >-
   {{-
     azimuth_caas_stackhpc_slurm_appliance_rocky8_image
     if azimuth_caas_stackhpc_slurm_appliance_rocky8_image is defined
     else (
       (
-        community_images_image_ids.openhpc_v3
+        community_images_image_ids.openhpc
         if (
           community_images_image_ids is defined and
-          'openhpc_v3' in community_images_image_ids
+          'openhpc' in community_images_image_ids
         )
         else undef(hint = 'azimuth_caas_stackhpc_slurm_appliance_image is required')
       )

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -78,9 +78,15 @@ community_images_azimuth_images: |-
 community_images_slurm_base_url: >-
   https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images
 community_images_slurm:
-  openhpc:
-    name: openhpc-240116-1604-b3563a08  # https://github.com/stackhpc/ansible-slurm-appliance/pull/344
-    source_url: "{{ community_images_slurm_base_url }}/openhpc-240116-1604-b3563a08"
+  # both from https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.144
+  openhpc_v2: # RockyLinux 8
+    name: openhpc-RL8-240327-1050-4812f852
+    source_url: "{{ community_images_slurm_base_url }}/openhpc-RL8-240327-1050-4812f852"
+    source_disk_format: qcow2
+    container_format: bare
+  openhpc_v3: # RockyLinux 9
+    name: openhpc-RL9-240327-1026-4812f852
+    source_url: "{{ community_images_slurm_base_url }}/openhpc-RL9-240327-1026-4812f852"
     source_disk_format: qcow2
     container_format: bare
 

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -78,13 +78,8 @@ community_images_azimuth_images: |-
 community_images_slurm_base_url: >-
   https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images
 community_images_slurm:
-  # both from https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.144
-  openhpc_v2: # RockyLinux 8
-    name: openhpc-RL8-240327-1050-4812f852
-    source_url: "{{ community_images_slurm_base_url }}/openhpc-RL8-240327-1050-4812f852"
-    source_disk_format: qcow2
-    container_format: bare
-  openhpc_v3: # RockyLinux 9
+  # from https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.144
+  openhpc:
     name: openhpc-RL9-240327-1026-4812f852
     source_url: "{{ community_images_slurm_base_url }}/openhpc-RL9-240327-1026-4812f852"
     source_disk_format: qcow2


### PR DESCRIPTION
See https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.144 but note:
- RL8 and RL9 images now provided in community images. **RL9 is now the default**
- `azimuth` user now get sudo on all nodes and user's key is not injected into `rocky` user